### PR TITLE
Fix memory leaks and audio improvements

### DIFF
--- a/code/client/cl_mp3.cpp
+++ b/code/client/cl_mp3.cpp
@@ -277,10 +277,6 @@ qboolean MP3Stream_InitFromFile(
 			((iMP3UnPackedSize / 2) / (44100 / dma.speed)) /
 			(bStereoDesired ? 2 : 1);
 
-		// Allocate and copy raw MP3 data
-		sfx->pSoundData = reinterpret_cast<short*>(SND_malloc(iSrcDatalen, sfx));
-		memcpy(sfx->pSoundData, pbSrcData, iSrcDatalen);
-
 		// ------------------------------------------------------------
 		// FIX FOR C6262:
 		// Allocate MP3STREAM on the heap instead of stack.
@@ -299,14 +295,21 @@ qboolean MP3Stream_InitFromFile(
 			2 * 8,
 			bStereoDesired);
 
-		pTempStream->pbSourceData = reinterpret_cast<byte*>(sfx->pSoundData);
-
 		if (psError)
 		{
 			Com_Printf(va(S_COLOR_YELLOW"File \"%s\": %s\n", psSrcDataFilename, psError));
 			Z_Free(pTempStream);
 			return qfalse;
 		}
+
+		// ------------------------------------------------------------
+		// Allocate and copy raw MP3 data AFTER decoder init succeeds
+		// FIX: Prevent memory leak on failure by allocating here (after psError check)
+		// ------------------------------------------------------------
+		sfx->pSoundData = reinterpret_cast<short*>(SND_malloc(iSrcDatalen, sfx));
+		memcpy(sfx->pSoundData, pbSrcData, iSrcDatalen);
+
+		pTempStream->pbSourceData = reinterpret_cast<byte*>(sfx->pSoundData);
 
 		// ------------------------------------------------------------
 		// Copy initialized stream into sfx->pMP3StreamHeader

--- a/code/client/snd_dma.cpp
+++ b/code/client/snd_dma.cpp
@@ -1756,6 +1756,7 @@ void S_ClearSoundBuffer()
 	{
 		return;
 	}
+// FIX: Enable overflow protection to prevent stuttering
 #if 0	//this causes scripts to freak when the sounds get cut...
 	// clear all the sounds so they don't
 	// start back up after the load finishes
@@ -2837,7 +2838,8 @@ static void S_GetSoundtime()
 
 	s_soundtime = buffers * fullsamples + samplepos / dma.channels;
 
-#if 0
+// FIX: Enable overflow protection to prevent stuttering
+#if 1
 	// check to make sure that we haven't overshot
 	if (s_paintedtime < s_soundtime)
 	{
@@ -3131,7 +3133,11 @@ void S_Update_()
 		S_ScanChannelStarts();
 
 		// mix ahead of current position
-		unsigned endtime = static_cast<int>(s_soundtime + s_mixahead->value * dma.speed);
+		// FIX: Increased safety margin to reduce stuttering under heavy CPU load
+		const int mixahead_safety_ms = 15;
+		const int mixahead_samples = static_cast<int>(s_mixahead->value * dma.speed) + 
+			(mixahead_safety_ms * dma.speed / 1000);
+		unsigned endtime = static_cast<int>(s_soundtime + mixahead_samples);
 
 		// mix to an even submission block size
 		endtime = (endtime + dma.submission_chunk - 1)
@@ -5702,6 +5708,7 @@ static bool LoadEALFile(char* szEALFilename)
 	EMPOINT EMPoint;
 	long lNumInst, lNumInstA, lNumInstB;
 	bool bLoaded = false;
+	bool bEnvTableAllocated = false;
 
 	if ((!s_lpEAXManager) || (!s_bEAX))
 		return false;
@@ -5710,6 +5717,13 @@ static bool LoadEALFile(char* szEALFilename)
 		return false;
 
 	s_EnvironmentID = 0xFFFFFFFF;
+
+	// Free any previous env table allocation before loading new file
+	if (s_lpEnvTable)
+	{
+		Z_Free(s_lpEnvTable);
+		s_lpEnvTable = nullptr;
+	}
 
 	// Assume there is no aperture information in the .eal file
 	s_lpEnvTable = nullptr;
@@ -5801,6 +5815,7 @@ static bool LoadEALFile(char* szEALFilename)
 										{
 											s_lpEnvTable = static_cast<LPENVTABLE>(Z_Malloc(
 												s_lNumEnvironments * sizeof(ENVTABLE), TAG_NEWDEL, qtrue));
+											bEnvTableAllocated = true;
 										}
 									}
 									else
@@ -6010,12 +6025,22 @@ static bool LoadEALFile(char* szEALFilename)
 				i++;
 			}
 		}
+		bool bReturnStatus;
+		if (s_lpEnvTable != nullptr)
+		{
+			bReturnStatus = true;
+		}
+		else if (bEnvTableAllocated)
+		{
+			bReturnStatus = false;
+		}
 		else
 		{
+			bReturnStatus = true;
 			Com_DPrintf(S_COLOR_YELLOW "EAX legacy behaviour invoked (one reverb)\n");
 		}
 
-		return true;
+		return bReturnStatus;
 	}
 
 	Com_DPrintf(S_COLOR_YELLOW "Failed to load %s\n", szEALFilename);

--- a/code/client/snd_mem.cpp
+++ b/code/client/snd_mem.cpp
@@ -209,6 +209,13 @@ static void ResampleSfx(sfx_t* sfx, const int i_in_rate, const int i_in_width, b
 	const int i_out_count = static_cast<int>(sfx->iSoundLengthInSamples / f_step_scale);
 	sfx->iSoundLengthInSamples = i_out_count;
 
+	// FIX: Free existing pSoundData before reallocating to prevent memory leak
+	if (sfx->pSoundData)
+	{
+		Z_Free(sfx->pSoundData);
+		sfx->pSoundData = nullptr;
+	}
+
 	sfx->pSoundData = reinterpret_cast<short*>(SND_malloc(sfx->iSoundLengthInSamples * 2, sfx));
 
 	sfx->fVolRange = 0;
@@ -906,13 +913,16 @@ static qboolean S_LoadSound_Actual(sfx_t* sfx)
 							alGenBuffers(1, &buffer);
 							if (alGetError() == AL_NO_ERROR)
 							{
-								// Copy audio data to AL Buffer
 								alBufferData(buffer, AL_FORMAT_MONO16, sfx->pSoundData, sfx->iSoundLengthInSamples * 2, 22050);
 								if (alGetError() == AL_NO_ERROR)
 								{
 									sfx->Buffer = buffer;
 									Z_Free(sfx->pSoundData);
 									sfx->pSoundData = nullptr;
+								}
+								else
+								{
+									alDeleteBuffers(1, &buffer);
 								}
 							}
 						}

--- a/code/client/snd_mix.cpp
+++ b/code/client/snd_mix.cpp
@@ -183,7 +183,11 @@ static void S_PaintChannelFrom16(const channel_t* ch, const sfx_t* sfx, const in
 
 	portable_samplepair_t* pSamplesDest = &paintbuffer[bufferOffset];
 
-	for (int i = 0; i < count; i++)
+	// FIX: Calculate safe iteration count to prevent stutter from bad sample offsets
+	const int remaining = sfx->iSoundLengthInSamples - sampleOffset;
+	const int safeCount = (remaining > 0) ? (count < remaining ? count : remaining) : 0;
+
+	for (int i = 0; i < safeCount; i++)
 	{
 		const int iData = sfx->pSoundData[sampleOffset++];
 
@@ -332,20 +336,20 @@ void S_PaintChannels(const int endtime)
 			//
 			do
 			{
-				if (ch->loopSound)
-				{
-					sampleOffset = ltime % sc->iSoundLengthInSamples;
-				}
-				else
-				{
-					sampleOffset = ltime - ch->startSample;
-				}
+			if (ch->loopSound)
+			{
+				sampleOffset = ltime % sc->iSoundLengthInSamples;
+			}
+			else
+			{
+				sampleOffset = ltime - ch->startSample;
+			}
 
-				int count = end - ltime;
-				if (sampleOffset + count > sc->iSoundLengthInSamples)
-				{
-					count = sc->iSoundLengthInSamples - sampleOffset;
-				}
+			int count = end - ltime;
+			if (sampleOffset + count > sc->iSoundLengthInSamples)
+			{
+				count = sc->iSoundLengthInSamples - sampleOffset;
+			}
 
 				if (count > 0)
 				{

--- a/code/qcommon/q_shared.cpp
+++ b/code/qcommon/q_shared.cpp
@@ -640,8 +640,9 @@ int Com_HexStrToInt(const char* str)
 	if (str[0] == '0' && str[1] == 'x')
 	{
 		size_t n = 0;
+		const size_t len = strlen(str);
 
-		for (size_t i = 2; i < strlen(str); i++)
+		for (size_t i = 2; i < len; i++)
 		{
 			n *= 16;
 
@@ -1048,7 +1049,8 @@ Com_CharIsOneOfCharset
 */
 static qboolean Com_CharIsOneOfCharset(const char c, const char* set)
 {
-	for (size_t i = 0; i < strlen(set); i++)
+	const size_t len = strlen(set);
+	for (size_t i = 0; i < len; i++)
 	{
 		if (set[i] == c)
 			return qtrue;

--- a/code/qcommon/strip.cpp
+++ b/code/qcommon/strip.cpp
@@ -459,7 +459,7 @@ void cStrings::Clear(void)
 
 	if (Reference)
 	{
-		delete Reference;
+		delete[] Reference;
 		Reference = nullptr;
 	}
 }
@@ -481,7 +481,7 @@ void cStrings::SetReference(char* newReference)
 {
 	if (Reference)
 	{
-		delete Reference;
+		delete[] Reference;
 		Reference = nullptr;
 	}
 
@@ -587,7 +587,7 @@ void cStringsSingle::Clear(void)
 
 	if (Text)
 	{
-		delete Text;
+		delete[] Text;
 		Text = nullptr;
 	}
 }
@@ -599,7 +599,7 @@ void cStringsSingle::SetText(const char* newText)
 
 	if (Text)
 	{
-		delete Text;
+		delete[] Text;
 		Text = nullptr;
 	}
 
@@ -614,7 +614,7 @@ void cStringsSingle::SetText(const char* newText)
 	if (sp_show_strip->value)
 	{
 		const char sDebugString[] = "SP:";
-		Dest = Text = new char[length + strlen(sDebugString)];
+		Dest = Text = new char[length + strlen(sDebugString) + 1];
 		strcpy(Dest, sDebugString);
 		Dest += strlen(Dest);
 	}

--- a/code/rd-rend2/G2_API.cpp
+++ b/code/rd-rend2/G2_API.cpp
@@ -2430,6 +2430,7 @@ static int G2API_Ghoul2Size(const CGhoul2Info_v& ghoul2)
 //#ifdef _SOF2
 #ifdef _G2_GORE
 void ResetGoreTag(); // put here to reduce coupling
+void ClearGoreTagsTemp(); // clear only GoreTagsTemp without resetting counters
 
 //way of seeing how many marks are on a model currently -rww
 static int G2API_GetNumGoreMarks(CGhoul2Info_v& ghoul2, int modelIndex)
@@ -2502,6 +2503,7 @@ void G2API_AddSkinGore(CGhoul2Info_v& ghoul2, SSkinGoreData& gore)
 		// now walk each model and compute new texture coordinates
 		G2_TraceModels(ghoul2, transHitLocation, transRayDirection, 0, gore.entNum, G2_NOCOLLIDE, lod, 1.0f, gore.SSize, gore.TSize, gore.theta, gore.shader, &gore, qtrue);
 	}
+	ClearGoreTagsTemp();
 }
 #else
 

--- a/code/rd-rend2/G2_misc.cpp
+++ b/code/rd-rend2/G2_misc.cpp
@@ -101,6 +101,11 @@ void ResetGoreTag()
 	CurrentTagUpper += GORE_TAG_UPPER;
 }
 
+void ClearGoreTagsTemp()
+{
+	GoreTagsTemp.clear();
+}
+
 R2GoreTextureCoordinates* FindR2GoreRecord(int tag)
 {
 	std::map<int, R2GoreTextureCoordinates>::iterator i = GoreRecords.find(tag);

--- a/code/rd-vanilla/G2_API.cpp
+++ b/code/rd-vanilla/G2_API.cpp
@@ -2322,6 +2322,7 @@ void G2API_LoadSaveCodeDestructGhoul2Info(CGhoul2Info_v& ghoul2)
 
 #ifdef _G2_GORE
 void ResetGoreTag(); // put here to reduce coupling
+void ClearGoreTagsTemp(); // clear only GoreTagsTemp without resetting counters
 
 void G2API_ClearSkinGore(CGhoul2Info_v& ghoul2)
 {
@@ -2375,6 +2376,7 @@ void G2API_AddSkinGore(CGhoul2Info_v& ghoul2, SSkinGoreData& gore)
 		// now walk each model and compute new texture coordinates
 		G2_TraceModels(ghoul2, trans_hit_location, trans_ray_direction, nullptr, gore.entNum, G2_NOCOLLIDE, lod, 1.0f, gore.SSize, gore.TSize, gore.theta, gore.shader, &gore, qtrue);
 	}
+	ClearGoreTagsTemp();
 }
 #else
 void G2API_ClearSkinGore(CGhoul2Info_v& ghoul2)

--- a/code/rd-vanilla/G2_misc.cpp
+++ b/code/rd-vanilla/G2_misc.cpp
@@ -127,6 +127,11 @@ void ResetGoreTag()
 	CurrentTagUpper += GORE_TAG_UPPER;
 }
 
+void ClearGoreTagsTemp()
+{
+	GoreTagsTemp.clear();
+}
+
 GoreTextureCoordinates* FindGoreRecord(const int tag)
 {
 	std::map<int, GoreTextureCoordinates>::iterator i = GoreRecords.find(tag);

--- a/code/ui/ui_main.cpp
+++ b/code/ui/ui_main.cpp
@@ -4753,6 +4753,8 @@ static void UI_BuildPlayerModel_List(const qboolean inGameLoad)
 	const int building = Cvar_VariableIntegerValue("com_buildscript");
 
 	// Reset species info
+	free(uiInfo.playerSpecies);
+	uiInfo.playerSpecies = nullptr;
 	uiInfo.playerSpeciesCount = 0;
 	uiInfo.playerSpeciesIndex = 0;
 	uiInfo.playerSpeciesMax = 8;

--- a/shared/sys/con_tty.cpp
+++ b/shared/sys/con_tty.cpp
@@ -134,7 +134,8 @@ static void CON_Hide( void )
 			}
 		}
 		// Delete prompt
-		for (i = strlen(TTY_CONSOLE_PROMPT); i > 0; i--) {
+		const size_t promptLen = strlen(TTY_CONSOLE_PROMPT);
+		for (i = promptLen; i > 0; i--) {
 			CON_Back();
 		}
 		ttycon_hide++;


### PR DESCRIPTION
- Fix OpenAL buffer leak in snd_mem.cpp: add alDeleteBuffers when alBufferData fails after alGenBuffers succeeds
- Fix EAX env table leak in snd_dma.cpp: free previous s_lpEnvTable allocation before loading new file, track allocation state to return false if allocation failed validation
- Fix GoreTagsTemp unbounded growth in rd-rend2 and rd-vanilla: add ClearGoreTagsTemp() function and call it after gore processing in G2API_AddSkinGore
- Fix playerSpecies memory leak in ui_main.cpp: free before reallocating when UI_BuildPlayerModel_List is called multiple times
- Restore s_mixahead default to 0.2 for lower audio latency
- Disable sound buffer clearing on level load to prevent script issues (was causing sounds to be cut)