### PR TITLE
Fix Ghoul2 model not loaded error on new map

### DIFF
--- a/shared/rd-rend2/tr_cache.cpp
+++ b/shared/rd-rend2/tr_cache.cpp
@@ -259,6 +259,12 @@ qboolean CModelCacheManager::LevelLoadEnd(qboolean deleteUnusedByLevel)
 				bAtLeastOneModelFreed = qtrue;	// FIXME: is this correct? shouldn't it be in the next lower scope?
 			}
 
+			auto assetIt = FindAsset(it->path);
+			if (assetIt != assets.end())
+			{
+				assets.erase(assetIt);
+			}
+
 			it = files.erase(it);
 		}
 		else


### PR DESCRIPTION
LevelLoadEnd() was purging models from the files cache but not removing corresponding entries from the assets cache. This caused stale model handles to persist across map loads, making GetModelHandle() return invalid handles for freed model data.

Now cleans up the assets cache when purging models during level load end.