### PR TITLE
Fix stale model handles in DumpNonPure

### DIFF
--- a/shared/rd-rend2/tr_cache.cpp
+++ b/shared/rd-rend2/tr_cache.cpp
@@ -192,6 +192,12 @@ void CModelCacheManager::DumpNonPure(void)
 			if (it->pDiskImage)
 				Z_Free(it->pDiskImage);
 
+			auto assetIt = FindAsset(it->path);
+			if (assetIt != assets.end())
+			{
+				assets.erase(assetIt);
+			}
+
 			it = files.erase(it);
 		}
 		else


### PR DESCRIPTION
DumpNonPure() was also not cleaning up the assets cache when purging non-pure models, causing the same stale handle issue as LevelLoadEnd().