### PR TITLE
Fixed Linux GCC build: named anonymous enums/structs, fixed static_ca…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,7 +214,7 @@ elseif (("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU") OR ("${CMAKE_C_COMPILER_ID}" M
 	# ZLib explicitly declares symbols hidden, rather than defaulting to hidden.
 	#
 	# Note that -fvisibility=hidden is stronger than -fvisibility-inlines-hidden.
-	set(OPENJK_VISIBILITY_FLAGS "-fvisibility=hidden")
+	set(OPENJK_VISIBILITY_FLAGS "-fvisibility=default")
 
 	# removes the -rdynamic flag at linking (which causes crashes for some reason)
 	set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
@@ -233,7 +233,7 @@ elseif (("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU") OR ("${CMAKE_C_COMPILER_ID}" M
 	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 
 	# enable somewhat modern C++
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 	
 	if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
@@ -261,7 +261,7 @@ elseif (("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU") OR ("${CMAKE_C_COMPILER_ID}" M
 	endif()
 
 	if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-invalid-offsetof")
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-write-strings")
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-comment")

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -104,7 +104,11 @@ if(BuildSPEngine OR BuildJK2SPEngine)
 	else()
 		find_package(SDL2 REQUIRED)
 		set(SPEngineIncludeDirectories ${SPEngineIncludeDirectories} ${SDL2_INCLUDE_DIR})
-		set(SPEngineLibraries ${SPEngineLibraries} ${SDL2_LIBRARY})
+		if(SDL2_LIBRARY)
+			set(SPEngineLibraries ${SPEngineLibraries} ${SDL2_LIBRARY})
+		else()
+			set(SPEngineLibraries ${SPEngineLibraries} SDL2::SDL2)
+		endif()
 	endif()
 
 	#    Source Files
@@ -434,6 +438,11 @@ if(BuildSPEngine OR BuildJK2SPEngine)
 
 		# Hide symbols not explicitly marked public.
 		set_property(TARGET ${ProjectName} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
+
+		# Export symbols needed for internal linking and dlopen'd modules
+		if(UNIX AND NOT APPLE)
+			set_target_properties(${ProjectName} PROPERTIES LINK_FLAGS "-rdynamic")
+		endif()
 
 		set_target_properties(${ProjectName} PROPERTIES INCLUDE_DIRECTORIES "${SPEngineIncludeDirectories}")
 		set_target_properties(${ProjectName} PROPERTIES PROJECT_LABEL ${Label})

--- a/code/cgame/cg_effects.cpp
+++ b/code/cgame/cg_effects.cpp
@@ -1063,14 +1063,14 @@ void CG_PlayEffectID(const int fx_id, vec3_t origin, const vec3_t fwd)
 	CG_PlayEffect(fx_name, origin, fwd);
 }
 
-inline float random()
+inline float Q_random()
 {
 	return rand() / static_cast<float>(0x7fff);
 }
 
-inline float crandom()
+inline float Q_crandom()
 {
-	return 2.0F * (random() - 0.5F);
+	return 2.0F * (Q_random() - 0.5F);
 }
 
 /*
@@ -1088,54 +1088,54 @@ void CG_GibPlayer(vec3_t player_origin)
 	vec3_t origin, velocity{};
 
 	VectorCopy(player_origin, origin);
-	velocity[0] = crandom() * GIB_VELOCITY;
-	velocity[1] = crandom() * GIB_VELOCITY;
-	velocity[2] = GIB_JUMP + crandom() * GIB_VELOCITY;
+	velocity[0] = Q_crandom() * GIB_VELOCITY;
+	velocity[1] = Q_crandom() * GIB_VELOCITY;
+	velocity[2] = GIB_JUMP + Q_crandom() * GIB_VELOCITY;
 
 	VectorCopy(player_origin, origin);
-	velocity[0] = crandom() * GIB_VELOCITY;
-	velocity[1] = crandom() * GIB_VELOCITY;
-	velocity[2] = GIB_JUMP + crandom() * GIB_VELOCITY;
+	velocity[0] = Q_crandom() * GIB_VELOCITY;
+	velocity[1] = Q_crandom() * GIB_VELOCITY;
+	velocity[2] = GIB_JUMP + Q_crandom() * GIB_VELOCITY;
 
 	VectorCopy(player_origin, origin);
-	velocity[0] = crandom() * GIB_VELOCITY;
-	velocity[1] = crandom() * GIB_VELOCITY;
-	velocity[2] = GIB_JUMP + crandom() * GIB_VELOCITY;
+	velocity[0] = Q_crandom() * GIB_VELOCITY;
+	velocity[1] = Q_crandom() * GIB_VELOCITY;
+	velocity[2] = GIB_JUMP + Q_crandom() * GIB_VELOCITY;
 
 	VectorCopy(player_origin, origin);
-	velocity[0] = crandom() * GIB_VELOCITY;
-	velocity[1] = crandom() * GIB_VELOCITY;
-	velocity[2] = GIB_JUMP + crandom() * GIB_VELOCITY;
+	velocity[0] = Q_crandom() * GIB_VELOCITY;
+	velocity[1] = Q_crandom() * GIB_VELOCITY;
+	velocity[2] = GIB_JUMP + Q_crandom() * GIB_VELOCITY;
 
 	VectorCopy(player_origin, origin);
-	velocity[0] = crandom() * GIB_VELOCITY;
-	velocity[1] = crandom() * GIB_VELOCITY;
-	velocity[2] = GIB_JUMP + crandom() * GIB_VELOCITY;
+	velocity[0] = Q_crandom() * GIB_VELOCITY;
+	velocity[1] = Q_crandom() * GIB_VELOCITY;
+	velocity[2] = GIB_JUMP + Q_crandom() * GIB_VELOCITY;
 
 	VectorCopy(player_origin, origin);
-	velocity[0] = crandom() * GIB_VELOCITY;
-	velocity[1] = crandom() * GIB_VELOCITY;
-	velocity[2] = GIB_JUMP + crandom() * GIB_VELOCITY;
+	velocity[0] = Q_crandom() * GIB_VELOCITY;
+	velocity[1] = Q_crandom() * GIB_VELOCITY;
+	velocity[2] = GIB_JUMP + Q_crandom() * GIB_VELOCITY;
 
 	VectorCopy(player_origin, origin);
-	velocity[0] = crandom() * GIB_VELOCITY;
-	velocity[1] = crandom() * GIB_VELOCITY;
-	velocity[2] = GIB_JUMP + crandom() * GIB_VELOCITY;
+	velocity[0] = Q_crandom() * GIB_VELOCITY;
+	velocity[1] = Q_crandom() * GIB_VELOCITY;
+	velocity[2] = GIB_JUMP + Q_crandom() * GIB_VELOCITY;
 
 	VectorCopy(player_origin, origin);
-	velocity[0] = crandom() * GIB_VELOCITY;
-	velocity[1] = crandom() * GIB_VELOCITY;
-	velocity[2] = GIB_JUMP + crandom() * GIB_VELOCITY;
+	velocity[0] = Q_crandom() * GIB_VELOCITY;
+	velocity[1] = Q_crandom() * GIB_VELOCITY;
+	velocity[2] = GIB_JUMP + Q_crandom() * GIB_VELOCITY;
 
 	VectorCopy(player_origin, origin);
-	velocity[0] = crandom() * GIB_VELOCITY;
-	velocity[1] = crandom() * GIB_VELOCITY;
-	velocity[2] = GIB_JUMP + crandom() * GIB_VELOCITY;
+	velocity[0] = Q_crandom() * GIB_VELOCITY;
+	velocity[1] = Q_crandom() * GIB_VELOCITY;
+	velocity[2] = GIB_JUMP + Q_crandom() * GIB_VELOCITY;
 
 	VectorCopy(player_origin, origin);
-	velocity[0] = crandom() * GIB_VELOCITY;
-	velocity[1] = crandom() * GIB_VELOCITY;
-	velocity[2] = GIB_JUMP + crandom() * GIB_VELOCITY;
+	velocity[0] = Q_crandom() * GIB_VELOCITY;
+	velocity[1] = Q_crandom() * GIB_VELOCITY;
+	velocity[2] = GIB_JUMP + Q_crandom() * GIB_VELOCITY;
 }
 
 constexpr auto DECAPITATE_VELOCITY = 3000;
@@ -1147,22 +1147,22 @@ void CG_GibPlayerHeadshot(vec3_t player_origin)
 
 	VectorCopy(player_origin, origin);
 	origin[2] += 25;
-	velocity[0] = crandom() * DECAPITATE_VELOCITY;
-	velocity[1] = crandom() * DECAPITATE_VELOCITY;
-	velocity[2] = HEAD_JUMP + crandom() * DECAPITATE_VELOCITY;
+	velocity[0] = Q_crandom() * DECAPITATE_VELOCITY;
+	velocity[1] = Q_crandom() * DECAPITATE_VELOCITY;
+	velocity[2] = HEAD_JUMP + Q_crandom() * DECAPITATE_VELOCITY;
 	//delete from here
 	VectorCopy(player_origin, origin);
-	velocity[0] = crandom() * DECAPITATE_VELOCITY;
-	velocity[1] = crandom() * DECAPITATE_VELOCITY;
-	velocity[2] = HEAD_JUMP + crandom() * DECAPITATE_VELOCITY;
+	velocity[0] = Q_crandom() * DECAPITATE_VELOCITY;
+	velocity[1] = Q_crandom() * DECAPITATE_VELOCITY;
+	velocity[2] = HEAD_JUMP + Q_crandom() * DECAPITATE_VELOCITY;
 
 	VectorCopy(player_origin, origin);
-	velocity[0] = crandom() * DECAPITATE_VELOCITY;
-	velocity[1] = crandom() * DECAPITATE_VELOCITY;
-	velocity[2] = HEAD_JUMP + crandom() * DECAPITATE_VELOCITY;
+	velocity[0] = Q_crandom() * DECAPITATE_VELOCITY;
+	velocity[1] = Q_crandom() * DECAPITATE_VELOCITY;
+	velocity[2] = HEAD_JUMP + Q_crandom() * DECAPITATE_VELOCITY;
 
 	VectorCopy(player_origin, origin);
-	velocity[0] = crandom() * DECAPITATE_VELOCITY;
-	velocity[1] = crandom() * DECAPITATE_VELOCITY;
-	velocity[2] = HEAD_JUMP + crandom() * DECAPITATE_VELOCITY;
+	velocity[0] = Q_crandom() * DECAPITATE_VELOCITY;
+	velocity[1] = Q_crandom() * DECAPITATE_VELOCITY;
+	velocity[2] = HEAD_JUMP + Q_crandom() * DECAPITATE_VELOCITY;
 }

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -73,8 +73,8 @@ constexpr auto MAX_MARK_POLYS = 256;
 constexpr auto STAT_MINUS = 10; // num frame for '-' stats digit;
 
 constexpr auto ICON_SIZE = 48;
-constexpr auto CHAR_WIDTH = 32;
-constexpr auto CHAR_HEIGHT = 48;
+#define	CHAR_WIDTH			32
+#define	CHAR_HEIGHT			48
 constexpr auto TEXT_ICON_SPACE = 4;
 
 constexpr auto CHARSMALL_WIDTH = 16;
@@ -285,7 +285,7 @@ using localEntity_t = struct localEntity_s
 // each IT_* item has an associated itemInfo_t
 // that constains media references necessary to present the
 // item and its effects
-using itemInfo_t = struct
+using itemInfo_t = struct itemInfo_t
 {
 	qboolean registered;
 	qhandle_t models;
@@ -327,7 +327,7 @@ using overrides_t = struct
 // all cg.stepTime, cg.duckTime, cg.landTime, etc are set to cg.time when the action
 // occurs, and they will have visible effects for #define STEP_TIME or whatever msec after
 
-using cg_t = struct
+using cg_t = struct cg_s
 {
 	int clientFrame; // incremented each frame
 

--- a/code/cgame/cg_main.cpp
+++ b/code/cgame/cg_main.cpp
@@ -487,9 +487,6 @@ vmCvar_t cg_gunMomentumInterval;
 vmCvar_t cg_setVaderBreath;
 vmCvar_t cg_setVaderBreathdamaged;
 vmCvar_t cg_com_outcast;
-vmCvar_t g_update7firststartup;
-
-vmCvar_t g_totgfirststartup;
 
 vmCvar_t cg_drawwidescreenmode;
 
@@ -709,9 +706,6 @@ static cvarTable_t cvarTable[] = {
 	{&cg_setVaderBreath, "cg_setVaderBreath", "0", CVAR_ARCHIVE | CVAR_SAVEGAME | CVAR_NORESTART},
 	{&cg_setVaderBreathdamaged, "cg_setVaderBreathdamaged", "0", CVAR_ARCHIVE | CVAR_SAVEGAME | CVAR_NORESTART},
 	{&cg_com_outcast, "com_outcast", "0", CVAR_ARCHIVE | CVAR_SAVEGAME | CVAR_NORESTART},
-	{&g_update7firststartup, "g_update7firststartup", "1", 0},
-
-	{&g_totgfirststartup, "g_totgfirststartup", "1", 0},
 
 	{&cg_drawwidescreenmode, "cg_drawwidescreenmode", "0", CVAR_ARCHIVE | CVAR_SAVEGAME | CVAR_NORESTART},
 

--- a/code/cgame/cg_media.h
+++ b/code/cgame/cg_media.h
@@ -803,7 +803,7 @@ using cgEffects_t = struct
 constexpr auto STRIPED_LEVELNAME_VARIATIONS = 3;
 // sigh, to cope with levels that use text from >1 SP file (plus 1 for common);
 
-using cgs_t = struct
+using cgs_t = struct cgs_t
 {
 	gameState_t gameState; // gamestate from server
 	glconfig_t glconfig; // rendering configuration

--- a/code/cgame/cg_public.h
+++ b/code/cgame/cg_public.h
@@ -220,6 +220,9 @@ using cgameImport_t = enum
 
 	CG_OPENJK_MENU_PAINT,
 	CG_OPENJK_GETMENU_BYNAME,
+
+	CG_SerenityJediEngine2026_MENU_PAINT,
+	CG_SerenityJediEngine2026_GETMENU_BYNAME,
 };
 
 #ifdef JK2_MODE

--- a/code/cgame/cg_syscalls.cpp
+++ b/code/cgame/cg_syscalls.cpp
@@ -28,7 +28,12 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 //prototypes
 extern void CG_PreInit();
 
-static intptr_t(QDECL* Q_syscall)(intptr_t arg, ...) = reinterpret_cast<intptr_t(__cdecl*)(intptr_t, ...)>(-1);
+static intptr_t(QDECL* Q_syscall)(intptr_t arg, ...) =
+#ifdef _WIN32
+	reinterpret_cast<intptr_t(__cdecl*)(intptr_t, ...)>(-1);
+#else
+	reinterpret_cast<intptr_t(*)(intptr_t, ...)>(-1);
+#endif
 
 extern "C" Q_EXPORT void QDECL dllEntry(intptr_t(QDECL* syscallptr)(intptr_t arg, ...))
 {

--- a/code/cgame/cg_weapons.cpp
+++ b/code/cgame/cg_weapons.cpp
@@ -402,12 +402,12 @@ void CG_RegisterWeapon(const int weapon_num)
 	// give ourselves the functions if we can
 	if (weaponData[weapon_num].func)
 	{
-		weaponInfo->missileTrailFunc = static_cast<void(*)(centity_s*, const weaponInfo_s*)>(weaponData[weapon_num].
+		weaponInfo->missileTrailFunc = reinterpret_cast<void(*)(centity_s*, const weaponInfo_s*)>(weaponData[weapon_num].
 			func);
 	}
 	if (weaponData[weapon_num].altfunc)
 	{
-		weaponInfo->alt_missileTrailFunc = static_cast<void(*)(centity_s*, const weaponInfo_s*)>(weaponData[weapon_num].
+		weaponInfo->alt_missileTrailFunc = reinterpret_cast<void(*)(centity_s*, const weaponInfo_s*)>(weaponData[weapon_num].
 			altfunc);
 	}
 

--- a/code/client/cl_cgame.cpp
+++ b/code/client/cl_cgame.cpp
@@ -61,8 +61,8 @@ qboolean CL_InitCGameVM(void* gameLibrary)
 	using SyscallProc = intptr_t(intptr_t, ...);
 	using DllEntryProc = void(SyscallProc*);
 
-	const auto dll_entry = static_cast<DllEntryProc*>(Sys_LoadFunction(gameLibrary, "dllEntry"));
-	cgvm.entryPoint = static_cast<intptr_t(*)(int, ...)>(Sys_LoadFunction(gameLibrary, "vmMain"));
+	const auto dll_entry = reinterpret_cast<DllEntryProc*>(Sys_LoadFunction(gameLibrary, "dllEntry"));
+	cgvm.entryPoint = reinterpret_cast<intptr_t(*)(int, ...)>(Sys_LoadFunction(gameLibrary, "vmMain"));
 
 	if (!cgvm.entryPoint || !dll_entry)
 	{

--- a/code/client/cl_main.cpp
+++ b/code/client/cl_main.cpp
@@ -1193,7 +1193,7 @@ void CL_InitRef()
 
 	memset(&rit, 0, sizeof(rit));
 
-	const auto GetRefAPI = static_cast<GetRefAPI_t>(Sys_LoadFunction(rendererLib, "GetRefAPI"));
+	const auto GetRefAPI = reinterpret_cast<GetRefAPI_t>(Sys_LoadFunction(rendererLib, "GetRefAPI"));
 	if (!GetRefAPI)
 		Com_Error(ERR_FATAL, "Can't load symbol GetRefAPI: '%s'", Sys_LibraryError());
 

--- a/code/client/cl_mp3.h
+++ b/code/client/cl_mp3.h
@@ -31,7 +31,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "snd_local.h"
 #endif
 
-using id3v1_1 = struct
+using id3v1_1 = struct id3v1_1_s
 {
 	char id[3];
 	char title[30]; // <file basename>

--- a/code/client/client.h
+++ b/code/client/client.h
@@ -70,7 +70,7 @@ constexpr auto MAX_PARSE_ENTITIES = 512;
 
 extern int g_console_field_width;
 
-using clientActive_t = struct
+using clientActive_t = struct clientActive_s
 {
 	int timeoutcount;
 
@@ -145,7 +145,7 @@ or just a streaming cinematic.
 =============================================================================
 */
 
-using clientConnection_t = struct
+using clientConnection_t = struct clientConnection_s
 {
 	int lastPacketSentTime; // for retransmits
 	int lastPacketTime;
@@ -179,7 +179,7 @@ no client connection is active at all
 ==================================================================
 */
 
-using clientStatic_t = struct
+using clientStatic_t = struct clientStatic_s
 {
 	connstate_t state; // connection status
 
@@ -213,7 +213,7 @@ using clientStatic_t = struct
 constexpr auto CON_TEXTSIZE = 0x30000; //was 32768;
 constexpr auto NUM_CON_TIMES = 4;
 
-using console_t = struct
+using console_t = struct console_s
 {
 	qboolean initialized;
 

--- a/code/client/snd_local.h
+++ b/code/client/snd_local.h
@@ -59,7 +59,7 @@ extern void AS_Free();
 constexpr auto PAINTBUFFER_SIZE = 1024;
 
 // !!! if this is changed, the asm code must change !!!
-using portable_samplepair_t = struct
+using portable_samplepair_t = struct portable_samplepair_s
 {
 	int left; // the final values will be clamped to +/- 0x00ffff00 and shifted down
 	int right;
@@ -100,7 +100,7 @@ using sfx_t = struct sfx_s
 	sfx_s* next; // only used because of hash table when registering
 };
 
-using dma_t = struct
+using dma_t = struct dma_s
 {
 	int channels;
 	int samples; // mono samples in buffer
@@ -114,7 +114,7 @@ constexpr auto START_SAMPLE_IMMEDIATE = 0x7fffffff;
 
 // Open AL specific
 #ifdef USE_OPENAL
-using STREAMINGBUFFER = struct
+using STREAMINGBUFFER = struct STREAMINGBUFFER_s
 {
 	ALuint BufferID;
 	ALuint Status;
@@ -128,7 +128,7 @@ constexpr auto STREAMING_BUFFER_SIZE = 4608; // 4 decoded MP3 frames;
 constexpr auto QUEUED = 1;
 constexpr auto UNQUEUED = 2;
 
-using channel_t = struct
+using channel_t = struct channel_s
 {
 	// back-indented fields new in TA codebase, will re-format when MP3 code finished -ste
 	// note: field missing in TA: qboolean	loopSound;		// from an S_AddLoopSound call, cleared each frame

--- a/code/client/snd_music.h
+++ b/code/client/snd_music.h
@@ -28,7 +28,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define SND_MUSIC_H
 
 // if you change this enum, you MUST update the #defines below
-using MusicState_e = enum
+using MusicState_e = enum MusicState_e_
 {
 	//( eBGRNDTRACK_DATABEGIN )			// begin-label for FOR loops
 	//

--- a/code/game/anims.h
+++ b/code/game/anims.h
@@ -24,7 +24,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define __ANIMS_H__
 // playerAnimations
 
-using animNumber_t = enum //# animNumber_e
+using animNumber_t = enum animNumber_e //# animNumber_e
 {
 	//=================================================
 	//HEAD ANIMS

--- a/code/game/b_public.h
+++ b/code/game/b_public.h
@@ -117,7 +117,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 //#endif //__DEBUG
 
-using visibility_t = enum
+using visibility_t = enum visibility_e
 {
 	VIS_UNKNOWN,
 	VIS_NOT,
@@ -127,7 +127,7 @@ using visibility_t = enum
 	VIS_SHOOT
 };
 
-using spot_t = enum
+using spot_t = enum spot_e
 {
 	SPOT_ORIGIN,
 	SPOT_CHEST,

--- a/code/game/bg_local.h
+++ b/code/game/bg_local.h
@@ -34,7 +34,7 @@ constexpr auto OVERCLIP = 1.001F;
 // all of the locals will be zeroed before each
 // pmove, just to make damn sure we don't have
 // any differences when running on client or server
-using pml_t = struct
+using pml_t = struct pml_t
 {
 	vec3_t forward, right, up;
 	float frametime;

--- a/code/game/bg_pmove.cpp
+++ b/code/game/bg_pmove.cpp
@@ -12685,7 +12685,7 @@ int PM_ReadyPoseForSaberAnimLevel(void)
 // Changes:   Cleaned structure, explicit qtrue/qfalse, no implicit bool,
 //            comments added, no asserts, clean compile.
 // ======================================================================
-static int PM_ReadyPoseForSaberAnimLevelAMD(void)
+int PM_ReadyPoseForSaberAnimLevelAMD(void)
 {
 	int anim = BOTH_STAND2; // default fallback
 
@@ -12755,7 +12755,7 @@ static int PM_ReadyPoseForSaberAnimLevelAMD(void)
 // Changes:   Clean structure, explicit qtrue/qfalse, fixed precedence bugs,
 //            comments added, no implicit bool→qboolean, safe defaults.
 // ======================================================================
-static int PM_BlockingPoseForSaberAnimLevelSingleAMD(void)
+int PM_BlockingPoseForSaberAnimLevelSingleAMD(void)
 {
 	// Start with the normal ready pose
 	int anim = PM_ReadyPoseForSaberAnimLevel();

--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -267,7 +267,7 @@ constexpr auto PMF_ACCURATE_MISSILE_BLOCK_HELD = 1 << 24;
 constexpr auto MAXTOUCH = 32;
 
 using gentity_t = struct gentity_s;
-using pmove_t = struct
+using pmove_t = struct pmove_t
 {
 	// state (in / out)
 	playerState_t* ps;

--- a/code/game/bstate.h
+++ b/code/game/bstate.h
@@ -24,7 +24,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define __BSTATE_H__
 
 //bstate.h
-using bState_t = enum //# bState_e
+using bState_t = enum bState_e //# bState_e
 {
 	//These take over only if script allows them to be autonomous
 	BS_DEFAULT = 0,

--- a/code/game/channels.h
+++ b/code/game/channels.h
@@ -25,7 +25,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 //	are different choices to offer in the pulldown box. I know, it's tacky, but ModView wasn't planned as an
 //	editor and this was never an external file. A great combination...   - Ste.
 //
-using soundChannel_t = enum //# soundChannel_e
+using soundChannel_t = enum soundChannel_e // soundChannel_e
 {
 	CHAN_AUTO,
 	//## %s !!"W:\game\base\!!sound\*.wav;*.mp3" # Auto-picks an empty channel to play sound on

--- a/code/game/g_active.cpp
+++ b/code/game/g_active.cpp
@@ -1747,7 +1747,7 @@ Find all trigger entities that ent's current position touches.
 Spectators will only interact with teleporters.
 ============
 */
-static void G_TouchTriggers(gentity_t* ent)
+void G_TouchTriggers(gentity_t* ent)
 {
 	// FIX: move large array off the stack
 	static gentity_t* touch[MAX_GENTITIES];

--- a/code/game/g_functions.h
+++ b/code/game/g_functions.h
@@ -386,7 +386,7 @@ extern void shipboundary_touch(gentity_t* self, gentity_t* other, trace_t* trace
 extern void hyperspace_touch(const gentity_t* self, gentity_t* other, trace_t* trace);
 
 //	void		(*use)(gentity_t *self, gentity_t *other, gentity_t *activator);
-using useFunc_t = enum
+using useFunc_t = enum useFunc_t
 {
 	useF_NULL = 0,
 	//

--- a/code/game/g_public.h
+++ b/code/game/g_public.h
@@ -74,7 +74,7 @@ class CRagDollParams;
 
 using gentity_t = struct gentity_s;
 
-using SavedGameJustLoaded_e = enum
+using SavedGameJustLoaded_e = enum SavedGameJustLoaded_e_
 {
 	eNO = 0,
 	eFULL,
@@ -143,7 +143,7 @@ class CMiniHeap;
 /*
 Ghoul2 Insert End
 */
-using game_import_t = struct
+using game_import_t = struct game_import_s
 {
 	//============== general Quake services ==================
 
@@ -392,7 +392,7 @@ using game_import_t = struct
 //
 // functions exported by the game subsystem
 //
-using game_export_t = struct
+using game_export_t = struct game_export_s
 {
 	int apiversion;
 

--- a/code/game/g_shared.h
+++ b/code/game/g_shared.h
@@ -36,7 +36,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 #define	FOFS(x) offsetof(gentity_t, x)
 
-using taskID_t = enum //# taskID_e
+using taskID_t = enum taskID_e //# taskID_e
 {
 	TID_CHAN_VOICE = 0,
 	// Waiting for a voice sound to complete
@@ -63,7 +63,7 @@ using taskID_t = enum //# taskID_e
 	// for def of taskID array
 };
 
-using material_t = enum //# material_e
+using material_t = enum material_t //# material_e
 {
 	MAT_METAL = 0,
 	// scorched blue-grey metal

--- a/code/game/g_utils.cpp
+++ b/code/game/g_utils.cpp
@@ -850,19 +850,19 @@ static gentity_t* find_remove_able_gent(void)
 		if (!e->classname)
 			continue;
 
-		if (stricmp(e->classname, "item_shield") == 0
-			|| stricmp(e->classname, "item_Barrier") == 0
-			|| stricmp(e->classname, "item_seeker") == 0
-			|| stricmp(e->classname, "misc_model_gun_rack") == 0
-			|| stricmp(e->classname, "misc_model_ammo_rack") == 0
-			|| stricmp(e->classname, "misc_model_cargo_small") == 0
-			|| stricmp(e->classname, "misc_ammo_floor_unit") == 0
-			|| stricmp(e->classname, "misc_shield_floor_unit") == 0
-			|| stricmp(e->classname, "ammo_blaster") == 0
-			|| stricmp(e->classname, "ammo_powercell") == 0
-			|| stricmp(e->classname, "item_binoculars") == 0
-			|| stricmp(e->classname, "item_shield_lrg_instant") == 0
-			|| stricmp(e->classname, "item_medpak_instant") == 0)
+		if (Q_stricmp(e->classname, "item_shield") == 0
+			|| Q_stricmp(e->classname, "item_Barrier") == 0
+			|| Q_stricmp(e->classname, "item_seeker") == 0
+			|| Q_stricmp(e->classname, "misc_model_gun_rack") == 0
+			|| Q_stricmp(e->classname, "misc_model_ammo_rack") == 0
+			|| Q_stricmp(e->classname, "misc_model_cargo_small") == 0
+			|| Q_stricmp(e->classname, "misc_ammo_floor_unit") == 0
+			|| Q_stricmp(e->classname, "misc_shield_floor_unit") == 0
+			|| Q_stricmp(e->classname, "ammo_blaster") == 0
+			|| Q_stricmp(e->classname, "ammo_powercell") == 0
+			|| Q_stricmp(e->classname, "item_binoculars") == 0
+			|| Q_stricmp(e->classname, "item_shield_lrg_instant") == 0
+			|| Q_stricmp(e->classname, "item_medpak_instant") == 0)
 		{
 			return e;
 		}
@@ -2141,6 +2141,7 @@ void TryUse(gentity_t* ent)
 {
 	trace_t trace;
 	vec3_t src, dest, vf;
+	gentity_t* target;
 
 	if (ent->s.number == 0 && g_npcdebug->integer == 1)
 	{
@@ -2181,7 +2182,7 @@ void TryUse(gentity_t* ent)
 		goto tryJetPack;
 	}
 
-	gentity_t* target = &g_entities[trace.entityNum];
+	target = &g_entities[trace.entityNum];
 
 	if (target && target->client && target->client->NPC_class == CLASS_VEHICLE)
 	{

--- a/code/game/g_vehicles.h
+++ b/code/game/g_vehicles.h
@@ -57,7 +57,7 @@ extern stringID_table_t VehicleTable[VH_NUM_VEHICLES + 1];
 //===========================================================================================================
 //START VEHICLE WEAPONS
 //===========================================================================================================
-using vehWeaponInfo_t = struct
+using vehWeaponInfo_t = struct vehWeaponInfo_t
 {
 	//*** IMPORTANT!!! *** vWeapFields table correponds to this structure!
 	char* name;
@@ -152,7 +152,7 @@ using vehWeaponStats_t = struct
 // Compiler pre-define.
 struct Vehicle_t;
 
-using vehicleInfo_t = struct
+using vehicleInfo_t = struct vehicleInfo_t
 {
 	//*** IMPORTANT!!! *** vehFields table correponds to this structure!
 	char* name; //unique name of the vehicle

--- a/code/game/genericparser2.cpp
+++ b/code/game/genericparser2.cpp
@@ -36,7 +36,7 @@ static void skipWhitespace(gsl::cstring_view& text, const bool allow_line_breaks
 {
 	auto whitespaceEnd = text.begin();
 	while (whitespaceEnd != text.end() // No EOF
-		&& std::isspace(*whitespaceEnd) // No End of Whitespace
+		&& std::isspace(static_cast<unsigned char>(*whitespaceEnd)) // No End of Whitespace
 		&& (allow_line_breaks || *whitespaceEnd != '\n')) // No unwanted newline
 	{
 		++whitespaceEnd;
@@ -82,7 +82,7 @@ static gsl::cstring_view removeTrailingWhitespace(const gsl::cstring_view& text)
 		text.begin(),
 		std::find_if_not(
 			std::reverse_iterator<const char*>(text.end()), std::reverse_iterator<const char*>(text.begin()),
-			std::isspace
+			[](char c) { return std::isspace(static_cast<unsigned char>(c)); }
 		).base()
 	};
 }
@@ -141,7 +141,7 @@ static gsl::cstring_view GetToken(gsl::cstring_view& text, const bool allow_line
 		return removeTrailingWhitespace(token);
 	}
 	// consume until first whitespace (if allowLineBreaks == false, that may be text.begin(); in that case token is empty.)
-	auto tokenEnd = std::find_if(text.begin(), text.end(), std::isspace);
+	auto tokenEnd = std::find_if(text.begin(), text.end(), [](char c) { return std::isspace(static_cast<unsigned char>(c)); });
 	gsl::cstring_view token{ text.begin(), tokenEnd };
 	text = { tokenEnd, text.end() };
 	return token;

--- a/code/game/teams.h
+++ b/code/game/teams.h
@@ -24,7 +24,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #ifndef TEAMS_H
 #define TEAMS_H
 
-using team_t = enum //# team_e
+using team_t = enum team_t //# team_e
 {
 	TEAM_FREE,
 	// caution, some code checks avia "if (!team_t_varname)" so I guess this should stay as entry 0, great or what? -slc
@@ -58,7 +58,7 @@ extern stringID_table_t TeamTable[];
 extern stringID_table_t FactionTable[];
 
 // This list is made up from the model directories, this MUST be in the same order as the ClassNames array in NPC_stats.cpp
-using class_t = enum
+using class_t = enum class_t
 {
 	CLASS_NONE,
 	// hopefully this will never be used by an npc, just covering all bases

--- a/code/game/weapons.h
+++ b/code/game/weapons.h
@@ -31,7 +31,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 #include "../qcommon/q_shared.h"
 
-using weapon_t = enum //# weapon_e
+using weapon_t = enum weapon_e //# weapon_e
 {
 	WP_NONE,
 
@@ -132,7 +132,7 @@ using weapon_t = enum //# weapon_e
 extern qboolean playerUsableWeapons[WP_NUM_WEAPONS];
 
 // AMMO_NONE must be first and AMMO_MAX must be last, cause weapon load validates based off of these vals
-using ammo_t = enum //# ammo_e
+using ammo_t = enum ammo_e //# ammo_e
 {
 	AMMO_NONE,
 	AMMO_FORCE,

--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -12880,7 +12880,7 @@ static void WP_SaberImpact(gentity_t* owner, gentity_t* saber, trace_t* trace)
 	}
 }
 
-static void WP_SaberInFlightReflectCheck(gentity_t* self)
+void WP_SaberInFlightReflectCheck(gentity_t* self)
 {
 	// --- EARLY VALIDATION ----------------------------------------------------
 	if (!self || !self->client)

--- a/code/game/wp_saber.h
+++ b/code/game/wp_saber.h
@@ -110,7 +110,7 @@ using saberLockResult_t = enum
 	LOCK_DRAW //both people fall back
 };
 
-using sabersLockMode_t = enum
+using sabersLockMode_t = enum sabersLockMode_t
 {
 	LOCK_FIRST = 0,
 	LOCK_TOP = LOCK_FIRST,
@@ -292,7 +292,7 @@ extern int G_CostForSpecialMove(int cost, qboolean kata_move = qfalse);
 extern gentity_t* G_DropSaberItem(const char* saberType, saber_colors_t saberColor, vec3_t saberPos, vec3_t saberVel,
 	vec3_t saberAngles, const gentity_t* copySaber = nullptr);
 
-using evasionType_t = enum
+using evasionType_t = enum evasionType_t
 {
 	EVASION_NONE = 0,
 	EVASION_PARRY,
@@ -308,7 +308,7 @@ using evasionType_t = enum
 	NUM_EVASION_TYPES
 };
 
-using swingType_t = enum
+using swingType_t = enum swingType_t
 {
 	SWING_FAST,
 	SWING_MEDIUM,
@@ -323,7 +323,7 @@ using swingType_t = enum
 #undef LS_NONE
 #endif
 
-using saber_moveName_t = enum
+using saber_moveName_t = enum saber_moveName_t
 {
 	// Invalid, or saber not armed
 	LS_INVALID = -1,
@@ -560,7 +560,7 @@ using saberQuadrant_t = enum
 	Q_NUM_QUADS
 };
 
-using saber_moveData_t = struct
+using saber_moveData_t = struct saber_moveData_t
 {
 	const char* name;
 	int animToUse;

--- a/code/mp3code/cup.c
+++ b/code/mp3code/cup.c
@@ -43,7 +43,7 @@ mods 11/15/95 for Layer I
 	   native mpeg rate. dec8.c adds oupuut conversion features.
 
 -------------------------------------
-int audio_decode_init(MPEG_HEAD *h, int framebytes_arg,
+int audio_decode_init(const MPEG_HEAD *h, int framebytes_arg,
 		 int reduction_code, int transform_code, int convert_code,
 		 int freq_limit)
 

--- a/code/qcommon/cm_local.h
+++ b/code/qcommon/cm_local.h
@@ -106,7 +106,7 @@ using cArea_t = struct
 	int floodvalid;
 };
 
-using clipMap_t = struct
+using clipMap_t = struct clipMap_s
 {
 	char name[MAX_QPATH];
 

--- a/code/qcommon/cm_polylib.h
+++ b/code/qcommon/cm_polylib.h
@@ -26,7 +26,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #ifndef CM_POLYLIB_H
 #define CM_POLYLIB_H
 
-using winding_t = struct
+using winding_t = struct winding_s
 {
 	int numpoints;
 	vec3_t p[4]; // variable sized

--- a/code/qcommon/ojk_saved_game_helper.h
+++ b/code/qcommon/ojk_saved_game_helper.h
@@ -353,8 +353,8 @@ namespace ojk
 
 		using DstNumeric = std::conditional_t<
 			std::is_signed<TSrc>::value,
-			std::intptr_t,
-			std::uintptr_t
+			::intptr_t,
+			::uintptr_t
 		>;
 
 		DstNumeric dst_number{};
@@ -636,8 +636,8 @@ namespace ojk
 	{
 		using DstNumeric = std::conditional_t<
 			std::is_signed<TSrc>::value,
-			std::intptr_t,
-			std::uintptr_t
+			::intptr_t,
+			::uintptr_t
 		>;
 
 		const DstNumeric dst_number = reinterpret_cast<DstNumeric>(src_value);

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -206,7 +206,7 @@ constexpr auto MAX_OSPATH = 256; // max length of a filesystem pathname;
 constexpr auto MAX_NAME_LENGTH = 32; // max length of a client name;
 
 // parameters for command buffer stuffing
-using cbufExec_t = enum
+using cbufExec_t = enum cbufExec_e
 {
 	EXEC_NOW,
 	// don't return until completed, a VM should NEVER use this,
@@ -231,7 +231,7 @@ constexpr auto LS_NUM_SWITCH = 32;
 #define	LS_LSNONE			0xff
 
 // print levels from renderer (FIXME: set up for game / cgame?)
-using printParm_t = enum
+using printParm_t = enum printParm_e
 {
 	PRINT_ALL,
 	PRINT_DEVELOPER,
@@ -241,7 +241,7 @@ using printParm_t = enum
 };
 
 // parameters to the main Error routine
-using errorParm_t = enum
+using errorParm_t = enum errorParm_e
 {
 	ERR_FATAL,
 	// exit the entire game with a pop up window
@@ -326,7 +326,7 @@ constexpr auto GIANTCHAR_HEIGHT = 48;
 #define NEW_FEEDER_V10
 
 // Player weapons effects
-using saber_colors_t = enum
+using saber_colors_t = enum saber_colors_e
 {
 	SABER_RED,
 	SABER_ORANGE,
@@ -342,7 +342,7 @@ using saber_colors_t = enum
 	SABER_RGB = 1 << 24
 };
 
-using holster_locations_t = enum
+using holster_locations_t = enum holster_locations_e
 {
 	HOLSTER_INVALID = -1,
 	HOLSTER_NONE = 0,
@@ -434,7 +434,7 @@ char* Com_SkipTokens(char* s, int numTokens, const char* sep);
 char* Com_SkipCharset(char* s, const char* sep);
 
 // mode parm for FS_FOpenFile
-using fsMode_t = enum
+using fsMode_t = enum fsMode_e
 {
 	FS_READ,
 	FS_WRITE,
@@ -442,7 +442,7 @@ using fsMode_t = enum
 	FS_APPEND_SYNC
 };
 
-using fsOrigin_t = enum
+using fsOrigin_t = enum fsOrigin_e
 {
 	FS_SEEK_CUR,
 	FS_SEEK_END,
@@ -540,7 +540,7 @@ using cvarHandle_t = int;
 
 // the modules that run in the virtual machine can't access the cvar_t directly,
 // so they must ask for structured updates
-using vmCvar_t = struct
+using vmCvar_t = struct vmCvar_s
 {
 	cvarHandle_t handle;
 	int modificationCount;
@@ -573,7 +573,7 @@ Ghoul2 Insert End
 
 constexpr auto MAX_G2_COLLISIONS = 32;
 // a trace is returned when a box is swept through the world
-using trace_t = struct
+using trace_t = struct trace_s
 {
 	qboolean allsolid = qfalse;
 	qboolean startsolid = qfalse;
@@ -617,13 +617,13 @@ using trace_t = struct
 // or ENTITYNUM_NONE, ENTITYNUM_WORLD
 
 // markfragments are returned by CM_MarkFragments()
-using markFragment_t = struct
+using markFragment_t = struct markFragment_s
 {
 	int firstPoint;
 	int numPoints;
 };
 
-using orientation_t = struct
+using orientation_t = struct orientation_s
 {
 	vec3_t origin;
 	vec3_t axis[3];
@@ -764,14 +764,14 @@ Ghoul2 Insert End
 constexpr auto BG_NUM_TOGGLEABLE_SURFACES = 31;
 
 constexpr auto MAX_GAMESTATE_CHARS = 32000;
-using gameState_t = struct
+using gameState_t = struct gameState_s
 {
 	int stringOffsets[MAX_CONFIGSTRINGS];
 	char stringData[MAX_GAMESTATE_CHARS];
 	int dataCount;
 };
 
-using forcePowers_t = enum
+using forcePowers_t = enum forcePowers_e
 {
 	FP_FIRST = 0,
 	//marker
@@ -829,7 +829,7 @@ using forcePowers_t = enum
 	NUM_FORCE_POWERS
 };
 
-using saberType_t = enum
+using saberType_t = enum saberType_e
 {
 	SABER_NONE = 0,
 	SABER_SINGLE,
@@ -894,7 +894,7 @@ constexpr auto MAX_PS_EVENTS = 2; // this must be a power of 2 unless you change
 #define MIN_WORLD_COORD		( -64*1024 )
 #define WORLD_SIZE			( MAX_WORLD_COORD - MIN_WORLD_COORD )
 
-using waterHeightLevel_t = enum
+using waterHeightLevel_t = enum waterHeightLevel_e
 {
 	WHL_NONE,
 	WHL_ANKLES,
@@ -907,7 +907,7 @@ using waterHeightLevel_t = enum
 };
 
 // !!!!!!! loadsave affecting struct !!!!!!!
-using saberTrail_t = struct
+using saberTrail_t = struct saberTrail_s
 {
 	// Actual trail stuff
 	int inAction; // controls whether should we even consider starting one
@@ -956,7 +956,7 @@ using saberTrail_t = struct
 constexpr auto MAX_SABER_TRAIL_SEGS = 8;
 
 // !!!!!!!!!!!!! loadsave affecting struct !!!!!!!!!!!!!!!
-using bladeInfo_t = struct
+using bladeInfo_t = struct bladeInfo_s
 {
 	qboolean active;
 	saber_colors_t color;
@@ -1017,7 +1017,7 @@ using bladeInfo_t = struct
 
 constexpr auto MAX_BLADES = 8;
 
-using saber_styles_t = enum
+using saber_styles_t = enum saber_styles_e
 {
 	SS_NONE = 0,
 	SS_FAST,
@@ -1093,7 +1093,7 @@ constexpr auto SFL_NO_ROLLS = 1 << 16; //if set, cannot roll;
 #define SFL2_TRANSITION_DAMAGE2		(1<<17)//if set, the blade does damage in start, transition and return anims (like strong style does)
 
 // !!!!!!!!!!!! loadsave affecting struct !!!!!!!!!!!!!!!!!!!!!!!!!!
-using saberInfo_t = struct
+using saberInfo_t = struct saberInfo_s
 {
 	char* name; //entry in sabers.cfg, if any
 	char* fullName; //the "Proper Name" of the saber, shown in the UI
@@ -2896,7 +2896,7 @@ using usercmd_t = struct usercmd_s
 // if entityState->solid == SOLID_BMODEL, modelindex is an inline model number
 constexpr auto SOLID_BMODEL = 0xffffff;
 
-using trType_t = enum
+using trType_t = enum trType_e
 {
 	// !!!!!!!!!!! LOADSAVE-affecting struct !!!!!!!!!!
 	TR_STATIONARY,
@@ -2910,7 +2910,7 @@ using trType_t = enum
 	TR_GRAVITY
 };
 
-using trajectory_t = struct
+using trajectory_t = struct trajectory_s
 {
 	// !!!!!!!!!!! LOADSAVE-affecting struct !!!!!!!!!!
 	trType_t trType;
@@ -3356,7 +3356,7 @@ using entityState_t = struct entityState_s
 	}
 };
 
-using connstate_t = enum
+using connstate_t = enum connstate_e
 {
 	CA_UNINITIALIZED,
 	CA_DISCONNECTED,
@@ -3417,7 +3417,7 @@ using SSkinGoreData = struct SSkinGoreData_s
 };
 
 //rww - used for my ik stuff (ported directly from mp)
-using sharedRagDollUpdateParams_t = struct
+using sharedRagDollUpdateParams_t = struct sharedRagDollUpdateParams_s
 {
 	vec3_t angles;
 	vec3_t position;
@@ -3427,7 +3427,7 @@ using sharedRagDollUpdateParams_t = struct
 };
 
 //rww - update parms for ik bone stuff
-using sharedIKMoveParams_t = struct
+using sharedIKMoveParams_t = struct sharedIKMoveParams_s
 {
 	char boneName[512]; //name of bone
 	vec3_t desiredOrigin; //world coordinate that this bone should be attempting to reach
@@ -3435,7 +3435,7 @@ using sharedIKMoveParams_t = struct
 	float movementSpeed; //how fast the bone should move toward the destination
 };
 
-using sharedSetBoneIKStateParams_t = struct
+using sharedSetBoneIKStateParams_t = struct sharedSetBoneIKStateParams_s
 {
 	vec3_t pcjMins; //ik joint limit
 	vec3_t pcjMaxs; //ik joint limit
@@ -3517,7 +3517,7 @@ extern parseData_t parseData[];
 extern int parseDataCount;
 
 // cinematic states
-using e_status = enum
+using e_status = enum e_status_e
 {
 	FMV_IDLE,
 	FMV_PLAY,
@@ -3543,7 +3543,7 @@ using memtag_t = unsigned;
 
 // stuff to help out during development process, force reloading/uncacheing of certain filetypes...
 //
-using ForceReload_e = enum
+using ForceReload_e = enum ForceReload_e2
 {
 	eForceReload_NOTHING,
 	eForceReload_BSP,
@@ -3551,7 +3551,7 @@ using ForceReload_e = enum
 	eForceReload_ALL
 };
 
-using ManualBlockingFlag_e = enum
+using ManualBlockingFlag_e = enum ManualBlockingFlag_e2
 {
 	HOLDINGBLOCK,
 	HOLDINGBLOCKANDATTACK,
@@ -3567,7 +3567,7 @@ using ManualBlockingFlag_e = enum
 	MBF_MISSILESTASIS,
 };
 
-using communicatingflags_e = enum
+using communicatingflags_e = enum communicatingflags_e2
 {
 	RESPECTING,
 	GESTURING,
@@ -3581,7 +3581,7 @@ using communicatingflags_e = enum
 	CF_SABERLOCK_ADVANCE,
 };
 
-using PlayerEffectFlags_e = enum
+using PlayerEffectFlags_e = enum PlayerEffectFlags_e2
 {
 	PEF_BURNING,
 	PEF_FREEZING,

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -48,7 +48,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 //
 // msg.c
 //
-using msg_t = struct
+using msg_t = struct msg_s
 {
 	qboolean allowoverflow; // if false, do a Com_Error
 	qboolean overflowed; // set to true if the buffer size failed (with allowoverflow set)
@@ -119,7 +119,7 @@ constexpr auto PORT_ANY = -1;
 
 constexpr auto MAX_RELIABLE_COMMANDS = 256; // max string commands buffered for restransmit;
 
-using netsrc_t = enum
+using netsrc_t = enum netsrc_e
 {
 	NS_CLIENT,
 	NS_SERVER
@@ -150,7 +150,7 @@ qboolean NET_GetLoopPacket(netsrc_t sock, netadr_t* net_from, msg_t* net_message
 Netchan handles packet fragmentation and out of order / duplicate suppression
 */
 
-using netchan_t = struct
+using netchan_t = struct netchan_s
 {
 	netsrc_t sock;
 
@@ -562,7 +562,7 @@ constexpr auto CONSOLE_PROMPT_CHAR = ']';
 constexpr auto MAX_EDIT_LINE = 256;
 constexpr auto COMMAND_HISTORY = 32;
 
-using field_t = struct
+using field_t = struct field_s
 {
 	int cursor;
 	int scroll;

--- a/code/qcommon/qfiles.h
+++ b/code/qcommon/qfiles.h
@@ -469,7 +469,7 @@ using mapVert_t = struct
 	byte color[MAXLIGHTMAPS][4];
 };
 
-using drawVert_t = struct
+using drawVert_t = struct drawVert_t
 {
 	vec3_t xyz;
 	float st[2];

--- a/code/rd-common/mdx_format.h
+++ b/code/rd-common/mdx_format.h
@@ -153,7 +153,7 @@ mdxaCompQuatBone_t
 ;
 
 #ifndef MDXABONEDEF
-using mdxaBone_t = struct
+using mdxaBone_t = struct mdxaBone_t
 {
 	float matrix[3][4];
 
@@ -286,7 +286,7 @@ using mdxmTriangle_t = struct
 // {
 // mdxVertex_t - this is an array with number of verts from the surface definition as its bounds. It contains normal info, texture coors and number of weightings for this bone
 // (this is now kept at 32 bytes for cache-aligning)
-using mdxmVertex_t = struct
+using mdxmVertex_t = struct mdxmVertex_t
 {
 	vec3_t normal;
 	vec3_t vertCoords;
@@ -350,7 +350,7 @@ static float G2_GetVertBoneWeight(const mdxmVertex_t* pVert, const int iWeightNu
 // {
 // mdxVertex_t - this is an array with number of verts from the surface definition as its bounds. It contains normal info, texture coors and number of weightings for this bone
 
-using mdxmVertexTexCoord_t = struct
+using mdxmVertexTexCoord_t = struct mdxmVertexTexCoord_t
 {
 	vec2_t texCoords;
 };
@@ -366,7 +366,7 @@ using mdxmVertexTexCoord_t = struct
 
 // mdxaHeader_t  - this contains the header for the file, with sanity checking and version checking, plus number of lod's to be expected
 //
-using mdxaHeader_t = struct
+using mdxaHeader_t = struct mdxaHeader_t
 {
 	//
 	// ( first 3 fields are same format as MD3/MDR so we can apply easy model-format-type checks )

--- a/code/rd-common/tr_image_png.cpp
+++ b/code/rd-common/tr_image_png.cpp
@@ -26,7 +26,9 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 #include "tr_common.h"
 #include <png.h>
+#ifdef _WIN32
 #include <libpng/pngget.c>
+#endif
 
 void user_write_data(const png_structp png_ptr, const png_bytep data, const png_size_t length) {
 	const fileHandle_t fp = *static_cast<fileHandle_t*>(png_get_io_ptr(png_ptr));
@@ -41,6 +43,7 @@ int RE_SavePNG(const char* filename, const byte* buf, const size_t width, const 
 	png_structp png_ptr;
 	png_infop info_ptr;
 	unsigned int y;
+	png_bytepp row_pointers = nullptr;
 	/* "status" contains the return value of this function. At first
 	it is set to a value which means 'failure'. When the routine
 	has finished its work, it is set to a value which means
@@ -86,7 +89,7 @@ int RE_SavePNG(const char* filename, const byte* buf, const size_t width, const 
 
 	/* Initialize rows of PNG. */
 
-	const auto row_pointers = static_cast<png_byte**>(png_malloc(png_ptr, height * sizeof(png_byte*)));
+	row_pointers = static_cast<png_byte**>(png_malloc(png_ptr, height * sizeof(png_byte*)));
 	for (y = 0; y < height; ++y) {
 		auto row = static_cast<png_byte*>(png_malloc(png_ptr, sizeof(uint8_t) * width * byteDepth));
 		row_pointers[height - y - 1] = row;

--- a/code/rd-common/tr_public.h
+++ b/code/rd-common/tr_public.h
@@ -32,7 +32,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 constexpr auto REF_API_VERSION = 20;
 
-using refimport_t = struct
+using refimport_t = struct refimport_t
 {
 	void (QDECL* Printf)(int printLevel, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
 	void (QDECL* Error)(int errorLevel, const char* fmt, ...) NORETURN_PTR __attribute__((format(printf, 2, 3)));
@@ -131,7 +131,7 @@ extern refimport_t ri;
 //
 // these are the functions exported by the refresh module
 //
-using refexport_t = struct
+using refexport_t = struct refexport_s
 {
 	// called before the library is unloaded
 	// if the system is just reconfiguring, pass destroyWindow = qfalse,

--- a/code/rd-common/tr_types.h
+++ b/code/rd-common/tr_types.h
@@ -94,7 +94,7 @@ extern int drawskyboxportal;
 
 using color4ub_t = byte[4];
 
-using polyVert_t = struct
+using polyVert_t = struct polyVert_t
 {
 	vec3_t xyz;
 	float st[2];
@@ -129,7 +129,7 @@ using refEntityType_t = enum
 	RT_MAX_REF_ENTITY_TYPE
 };
 
-using miniRefEntity_t = struct
+using miniRefEntity_t = struct miniRefEntity_t
 {
 	refEntityType_t		reType;
 	int					renderfx;
@@ -160,7 +160,7 @@ using miniRefEntity_t = struct
 	int			frame;				// also used as MODEL_BEAM's diameter
 };
 
-using refEntity_t = struct
+using refEntity_t = struct refEntity_s
 {
 	refEntityType_t reType;
 	int renderfx;
@@ -275,7 +275,7 @@ using refEntity_t = struct
 #define	MAX_RENDER_STRINGS			8
 #define	MAX_RENDER_STRING_LENGTH	32
 
-using refdef_t = struct
+using refdef_t = struct refdef_s
 {
 	int x, y, width, height;
 	float fov_x, fov_y;
@@ -296,7 +296,7 @@ using refdef_t = struct
 	//	char		text[MAX_RENDER_STRINGS][MAX_RENDER_STRING_LENGTH];
 };
 
-using stereoFrame_t = enum
+using stereoFrame_t = enum stereoFrame_e
 {
 	STEREO_CENTER,
 	STEREO_LEFT,

--- a/code/rd-rend2/G2_bones.cpp
+++ b/code/rd-rend2/G2_bones.cpp
@@ -584,8 +584,8 @@ qboolean G2_Set_Bone_Angles_Matrix(const CGhoul2Info* ghlInfo, boneInfo_v& blist
 	{
 		blist[index].flags &= ~(BONE_ANGLES_TOTAL);
 		blist[index].flags |= flags;
-		memcpy(&blist[index].matrix, &matrix, sizeof mdxaBone_t);
-		memcpy(&blist[index].newMatrix, &matrix, sizeof mdxaBone_t);
+		memcpy(&blist[index].matrix, &matrix, sizeof(mdxaBone_t));
+		memcpy(&blist[index].newMatrix, &matrix, sizeof(mdxaBone_t));
 		return qtrue;
 	}
 	return qfalse;

--- a/code/rd-vanilla/G2_bones.cpp
+++ b/code/rd-vanilla/G2_bones.cpp
@@ -433,7 +433,7 @@ static void G2_Generate_Matrix(const model_t* mod, boneInfo_v& blist, const int 
 	}
 
 	// keep a copy of the matrix in the newmatrix which is actually what we use
-	memcpy(&blist[index].newMatrix, &blist[index].matrix, sizeof mdxaBone_t);
+	memcpy(&blist[index].newMatrix, &blist[index].matrix, sizeof(mdxaBone_t));
 }
 
 //=========================================================================================
@@ -509,8 +509,8 @@ qboolean G2_Set_Bone_Angles_Matrix_Index(boneInfo_v& blist, const int index, con
 	blist[index].boneBlendStart = current_time;
 	blist[index].boneBlendTime = blend_time;
 
-	memcpy(&blist[index].matrix, &matrix, sizeof mdxaBone_t);
-	memcpy(&blist[index].newMatrix, &matrix, sizeof mdxaBone_t);
+	memcpy(&blist[index].matrix, &matrix, sizeof(mdxaBone_t));
+	memcpy(&blist[index].newMatrix, &matrix, sizeof(mdxaBone_t));
 	return qtrue;
 }
 
@@ -526,8 +526,8 @@ qboolean G2_Set_Bone_Angles_Matrix(const CGhoul2Info* ghlInfo, boneInfo_v& blist
 	{
 		blist[index].flags &= ~(BONE_ANGLES_TOTAL);
 		blist[index].flags |= flags;
-		memcpy(&blist[index].matrix, &matrix, sizeof mdxaBone_t);
-		memcpy(&blist[index].newMatrix, &matrix, sizeof mdxaBone_t);
+		memcpy(&blist[index].matrix, &matrix, sizeof(mdxaBone_t));
+		memcpy(&blist[index].newMatrix, &matrix, sizeof(mdxaBone_t));
 		return qtrue;
 	}
 	return qfalse;
@@ -1116,7 +1116,7 @@ static void G2_Generate_MatrixRag(boneInfo_v& blist, const int index)
 {
 	boneInfo_t& bone = blist[index]; //.sent;
 
-	memcpy(&bone.matrix, &bone.ragOverrideMatrix, sizeof mdxaBone_t);
+	memcpy(&bone.matrix, &bone.ragOverrideMatrix, sizeof(mdxaBone_t));
 #ifdef _DEBUG
 	for (int i = 0; i < 3; i++)
 	{
@@ -1126,7 +1126,7 @@ static void G2_Generate_MatrixRag(boneInfo_v& blist, const int index)
 		}
 	}
 #endif// _DEBUG
-	memcpy(&blist[index].newMatrix, &bone.matrix, sizeof mdxaBone_t);
+	memcpy(&blist[index].newMatrix, &bone.matrix, sizeof(mdxaBone_t));
 }
 
 int G2_Find_Bone_Rag(const CGhoul2Info* ghlInfo, const boneInfo_v& blist, const char* boneName)
@@ -1258,7 +1258,7 @@ static int G2_Set_Bone_Angles_Rag(const CGhoul2Info& ghoul2, boneInfo_v& blist, 
 					{0.0f, 0.0f, 1.0f, 0.0f}
 				}
 			};
-			memcpy(&bone.ragOverrideMatrix, &id, sizeof mdxaBone_t);
+			memcpy(&bone.ragOverrideMatrix, &id, sizeof(mdxaBone_t));
 			VectorClear(bone.anglesOffset);
 			VectorClear(bone.positionOffset);
 			VectorClear(bone.velocityEffector); // this is actually a velocity now
@@ -4254,7 +4254,7 @@ static int G2_Set_Bone_Angles_IK(const CGhoul2Info& ghoul2, boneInfo_v& blist, c
 					{0.0f, 0.0f, 1.0f, 0.0}
 				}
 			};
-			memcpy(&bone.ragOverrideMatrix, &id, sizeof mdxaBone_t);
+			memcpy(&bone.ragOverrideMatrix, &id, sizeof(mdxaBone_t));
 			VectorClear(bone.anglesOffset);
 			VectorClear(bone.positionOffset);
 			VectorClear(bone.velocityEffector); // this is actually a velocity now

--- a/code/rd-vanilla/tr_cmds.cpp
+++ b/code/rd-vanilla/tr_cmds.cpp
@@ -166,7 +166,7 @@ R_GetCommandBuffer
 returns NULL if there is not enough space for important commands
 ============
 */
-static void* R_GetCommandBuffer(const unsigned int bytes)
+void* R_GetCommandBuffer(const unsigned int bytes)
 {
 	return R_GetCommandBufferReserved(bytes, PAD(sizeof(swapBuffersCommand_t), sizeof(void*)));
 }

--- a/code/rd-vanilla/tr_init.cpp
+++ b/code/rd-vanilla/tr_init.cpp
@@ -506,9 +506,9 @@ static void GLimp_InitExtensions()
 	{
 		if (r_ext_multitexture->integer)
 		{
-			qglMultiTexCoord2fARB = static_cast<PFNGLMULTITEXCOORD2FARBPROC>(ri.GL_GetProcAddress("glMultiTexCoord2fARB"));
-			qglActiveTextureARB = static_cast<PFNGLACTIVETEXTUREARBPROC>(ri.GL_GetProcAddress("glActiveTextureARB"));
-			qglClientActiveTextureARB = static_cast<PFNGLCLIENTACTIVETEXTUREARBPROC>(ri.GL_GetProcAddress("glClientActiveTextureARB"));
+			qglMultiTexCoord2fARB = reinterpret_cast<PFNGLMULTITEXCOORD2FARBPROC>(ri.GL_GetProcAddress("glMultiTexCoord2fARB"));
+			qglActiveTextureARB = reinterpret_cast<PFNGLACTIVETEXTUREARBPROC>(ri.GL_GetProcAddress("glActiveTextureARB"));
+			qglClientActiveTextureARB = reinterpret_cast<PFNGLCLIENTACTIVETEXTUREARBPROC>(ri.GL_GetProcAddress("glClientActiveTextureARB"));
 
 			if (qglActiveTextureARB)
 			{
@@ -545,8 +545,8 @@ static void GLimp_InitExtensions()
 		if (r_ext_compiled_vertex_array->integer)
 		{
 			Com_Printf("...using GL_EXT_compiled_vertex_array\n");
-			qglLockArraysEXT = static_cast<PFNGLLOCKARRAYSEXTPROC>(ri.GL_GetProcAddress("glLockArraysEXT"));
-			qglUnlockArraysEXT = static_cast<PFNGLUNLOCKARRAYSEXTPROC>(ri.GL_GetProcAddress("glUnlockArraysEXT"));
+			qglLockArraysEXT = reinterpret_cast<PFNGLLOCKARRAYSEXTPROC>(ri.GL_GetProcAddress("glLockArraysEXT"));
+			qglUnlockArraysEXT = reinterpret_cast<PFNGLUNLOCKARRAYSEXTPROC>(ri.GL_GetProcAddress("glUnlockArraysEXT"));
 			if (!qglLockArraysEXT || !qglUnlockArraysEXT) {
 				Com_Error(ERR_FATAL, "bad getprocaddress");
 			}
@@ -573,19 +573,19 @@ static void GLimp_InitExtensions()
 			// NOTE: VV guys will _definetly_ not be able to use regcoms. Pixel Shaders are just as good though :-)
 			// NOTE: Also, this is an nVidia specific extension (of course), so fragment shaders would serve the same purpose
 			// if we needed some kind of fragment/pixel manipulation support.
-			qglCombinerParameterfvNV = static_cast<PFNGLCOMBINERPARAMETERFVNVPROC>(ri.GL_GetProcAddress("glCombinerParameterfvNV"));
-			qglCombinerParameterivNV = static_cast<PFNGLCOMBINERPARAMETERIVNVPROC>(ri.GL_GetProcAddress("glCombinerParameterivNV"));
-			qglCombinerParameterfNV = static_cast<PFNGLCOMBINERPARAMETERFNVPROC>(ri.GL_GetProcAddress("glCombinerParameterfNV"));
-			qglCombinerParameteriNV = static_cast<PFNGLCOMBINERPARAMETERINVPROC>(ri.GL_GetProcAddress("glCombinerParameteriNV"));
-			qglCombinerInputNV = static_cast<PFNGLCOMBINERINPUTNVPROC>(ri.GL_GetProcAddress("glCombinerInputNV"));
-			qglCombinerOutputNV = static_cast<PFNGLCOMBINEROUTPUTNVPROC>(ri.GL_GetProcAddress("glCombinerOutputNV"));
-			qglFinalCombinerInputNV = static_cast<PFNGLFINALCOMBINERINPUTNVPROC>(ri.GL_GetProcAddress("glFinalCombinerInputNV"));
-			qglGetCombinerInputParameterfvNV = static_cast<PFNGLGETCOMBINERINPUTPARAMETERFVNVPROC>(ri.GL_GetProcAddress("glGetCombinerInputParameterfvNV"));
-			qglGetCombinerInputParameterivNV = static_cast<PFNGLGETCOMBINERINPUTPARAMETERIVNVPROC>(ri.GL_GetProcAddress("glGetCombinerInputParameterivNV"));
-			qglGetCombinerOutputParameterfvNV = static_cast<PFNGLGETCOMBINEROUTPUTPARAMETERFVNVPROC>(ri.GL_GetProcAddress("glGetCombinerOutputParameterfvNV"));
-			qglGetCombinerOutputParameterivNV = static_cast<PFNGLGETCOMBINEROUTPUTPARAMETERIVNVPROC>(ri.GL_GetProcAddress("glGetCombinerOutputParameterivNV"));
-			qglGetFinalCombinerInputParameterfvNV = static_cast<PFNGLGETFINALCOMBINERINPUTPARAMETERFVNVPROC>(ri.GL_GetProcAddress("glGetFinalCombinerInputParameterfvNV"));
-			qglGetFinalCombinerInputParameterivNV = static_cast<PFNGLGETFINALCOMBINERINPUTPARAMETERIVNVPROC>(ri.GL_GetProcAddress("glGetFinalCombinerInputParameterivNV"));
+			qglCombinerParameterfvNV = reinterpret_cast<PFNGLCOMBINERPARAMETERFVNVPROC>(ri.GL_GetProcAddress("glCombinerParameterfvNV"));
+			qglCombinerParameterivNV = reinterpret_cast<PFNGLCOMBINERPARAMETERIVNVPROC>(ri.GL_GetProcAddress("glCombinerParameterivNV"));
+			qglCombinerParameterfNV = reinterpret_cast<PFNGLCOMBINERPARAMETERFNVPROC>(ri.GL_GetProcAddress("glCombinerParameterfNV"));
+			qglCombinerParameteriNV = reinterpret_cast<PFNGLCOMBINERPARAMETERINVPROC>(ri.GL_GetProcAddress("glCombinerParameteriNV"));
+			qglCombinerInputNV = reinterpret_cast<PFNGLCOMBINERINPUTNVPROC>(ri.GL_GetProcAddress("glCombinerInputNV"));
+			qglCombinerOutputNV = reinterpret_cast<PFNGLCOMBINEROUTPUTNVPROC>(ri.GL_GetProcAddress("glCombinerOutputNV"));
+			qglFinalCombinerInputNV = reinterpret_cast<PFNGLFINALCOMBINERINPUTNVPROC>(ri.GL_GetProcAddress("glFinalCombinerInputNV"));
+			qglGetCombinerInputParameterfvNV = reinterpret_cast<PFNGLGETCOMBINERINPUTPARAMETERFVNVPROC>(ri.GL_GetProcAddress("glGetCombinerInputParameterfvNV"));
+			qglGetCombinerInputParameterivNV = reinterpret_cast<PFNGLGETCOMBINERINPUTPARAMETERIVNVPROC>(ri.GL_GetProcAddress("glGetCombinerInputParameterivNV"));
+			qglGetCombinerOutputParameterfvNV = reinterpret_cast<PFNGLGETCOMBINEROUTPUTPARAMETERFVNVPROC>(ri.GL_GetProcAddress("glGetCombinerOutputParameterfvNV"));
+			qglGetCombinerOutputParameterivNV = reinterpret_cast<PFNGLGETCOMBINEROUTPUTPARAMETERIVNVPROC>(ri.GL_GetProcAddress("glGetCombinerOutputParameterivNV"));
+			qglGetFinalCombinerInputParameterfvNV = reinterpret_cast<PFNGLGETFINALCOMBINERINPUTPARAMETERFVNVPROC>(ri.GL_GetProcAddress("glGetFinalCombinerInputParameterfvNV"));
+			qglGetFinalCombinerInputParameterivNV = reinterpret_cast<PFNGLGETFINALCOMBINERINPUTPARAMETERIVNVPROC>(ri.GL_GetProcAddress("glGetFinalCombinerInputParameterivNV"));
 
 			// Validate the functions we need.
 			if (!qglCombinerParameterfvNV || !qglCombinerParameterivNV || !qglCombinerParameterfNV || !qglCombinerParameteriNV || !qglCombinerInputNV ||
@@ -641,25 +641,25 @@ static void GLimp_InitExtensions()
 	// If we support one or the other, load the shared function pointers.
 	if (b_arb_vertex_program || b_arb_fragment_program)
 	{
-		qglProgramStringARB = static_cast<PFNGLPROGRAMSTRINGARBPROC>(ri.GL_GetProcAddress("glProgramStringARB"));
-		qglBindProgramARB = static_cast<PFNGLBINDPROGRAMARBPROC>(ri.GL_GetProcAddress("glBindProgramARB"));
-		qglDeleteProgramsARB = static_cast<PFNGLDELETEPROGRAMSARBPROC>(ri.GL_GetProcAddress("glDeleteProgramsARB"));
-		qglGenProgramsARB = static_cast<PFNGLGENPROGRAMSARBPROC>(ri.GL_GetProcAddress("glGenProgramsARB"));
-		qglProgramEnvParameter4dARB = static_cast<PFNGLPROGRAMENVPARAMETER4DARBPROC>(ri.GL_GetProcAddress("glProgramEnvParameter4dARB"));
-		qglProgramEnvParameter4dvARB = static_cast<PFNGLPROGRAMENVPARAMETER4DVARBPROC>(ri.GL_GetProcAddress("glProgramEnvParameter4dvARB"));
-		qglProgramEnvParameter4fARB = static_cast<PFNGLPROGRAMENVPARAMETER4FARBPROC>(ri.GL_GetProcAddress("glProgramEnvParameter4fARB"));
-		qglProgramEnvParameter4fvARB = static_cast<PFNGLPROGRAMENVPARAMETER4FVARBPROC>(ri.GL_GetProcAddress("glProgramEnvParameter4fvARB"));
-		qglProgramLocalParameter4dARB = static_cast<PFNGLPROGRAMLOCALPARAMETER4DARBPROC>(ri.GL_GetProcAddress("glProgramLocalParameter4dARB"));
-		qglProgramLocalParameter4dvARB = static_cast<PFNGLPROGRAMLOCALPARAMETER4DVARBPROC>(ri.GL_GetProcAddress("glProgramLocalParameter4dvARB"));
-		qglProgramLocalParameter4fARB = static_cast<PFNGLPROGRAMLOCALPARAMETER4FARBPROC>(ri.GL_GetProcAddress("glProgramLocalParameter4fARB"));
-		qglProgramLocalParameter4fvARB = static_cast<PFNGLPROGRAMLOCALPARAMETER4FVARBPROC>(ri.GL_GetProcAddress("glProgramLocalParameter4fvARB"));
-		qglGetProgramEnvParameterdvARB = static_cast<PFNGLGETPROGRAMENVPARAMETERDVARBPROC>(ri.GL_GetProcAddress("glGetProgramEnvParameterdvARB"));
-		qglGetProgramEnvParameterfvARB = static_cast<PFNGLGETPROGRAMENVPARAMETERFVARBPROC>(ri.GL_GetProcAddress("glGetProgramEnvParameterfvARB"));
-		qglGetProgramLocalParameterdvARB = static_cast<PFNGLGETPROGRAMLOCALPARAMETERDVARBPROC>(ri.GL_GetProcAddress("glGetProgramLocalParameterdvARB"));
-		qglGetProgramLocalParameterfvARB = static_cast<PFNGLGETPROGRAMLOCALPARAMETERFVARBPROC>(ri.GL_GetProcAddress("glGetProgramLocalParameterfvARB"));
-		qglGetProgramivARB = static_cast<PFNGLGETPROGRAMIVARBPROC>(ri.GL_GetProcAddress("glGetProgramivARB"));
-		qglGetProgramStringARB = static_cast<PFNGLGETPROGRAMSTRINGARBPROC>(ri.GL_GetProcAddress("glGetProgramStringARB"));
-		qglIsProgramARB = static_cast<PFNGLISPROGRAMARBPROC>(ri.GL_GetProcAddress("glIsProgramARB"));
+		qglProgramStringARB = reinterpret_cast<PFNGLPROGRAMSTRINGARBPROC>(ri.GL_GetProcAddress("glProgramStringARB"));
+		qglBindProgramARB = reinterpret_cast<PFNGLBINDPROGRAMARBPROC>(ri.GL_GetProcAddress("glBindProgramARB"));
+		qglDeleteProgramsARB = reinterpret_cast<PFNGLDELETEPROGRAMSARBPROC>(ri.GL_GetProcAddress("glDeleteProgramsARB"));
+		qglGenProgramsARB = reinterpret_cast<PFNGLGENPROGRAMSARBPROC>(ri.GL_GetProcAddress("glGenProgramsARB"));
+		qglProgramEnvParameter4dARB = reinterpret_cast<PFNGLPROGRAMENVPARAMETER4DARBPROC>(ri.GL_GetProcAddress("glProgramEnvParameter4dARB"));
+		qglProgramEnvParameter4dvARB = reinterpret_cast<PFNGLPROGRAMENVPARAMETER4DVARBPROC>(ri.GL_GetProcAddress("glProgramEnvParameter4dvARB"));
+		qglProgramEnvParameter4fARB = reinterpret_cast<PFNGLPROGRAMENVPARAMETER4FARBPROC>(ri.GL_GetProcAddress("glProgramEnvParameter4fARB"));
+		qglProgramEnvParameter4fvARB = reinterpret_cast<PFNGLPROGRAMENVPARAMETER4FVARBPROC>(ri.GL_GetProcAddress("glProgramEnvParameter4fvARB"));
+		qglProgramLocalParameter4dARB = reinterpret_cast<PFNGLPROGRAMLOCALPARAMETER4DARBPROC>(ri.GL_GetProcAddress("glProgramLocalParameter4dARB"));
+		qglProgramLocalParameter4dvARB = reinterpret_cast<PFNGLPROGRAMLOCALPARAMETER4DVARBPROC>(ri.GL_GetProcAddress("glProgramLocalParameter4dvARB"));
+		qglProgramLocalParameter4fARB = reinterpret_cast<PFNGLPROGRAMLOCALPARAMETER4FARBPROC>(ri.GL_GetProcAddress("glProgramLocalParameter4fARB"));
+		qglProgramLocalParameter4fvARB = reinterpret_cast<PFNGLPROGRAMLOCALPARAMETER4FVARBPROC>(ri.GL_GetProcAddress("glProgramLocalParameter4fvARB"));
+		qglGetProgramEnvParameterdvARB = reinterpret_cast<PFNGLGETPROGRAMENVPARAMETERDVARBPROC>(ri.GL_GetProcAddress("glGetProgramEnvParameterdvARB"));
+		qglGetProgramEnvParameterfvARB = reinterpret_cast<PFNGLGETPROGRAMENVPARAMETERFVARBPROC>(ri.GL_GetProcAddress("glGetProgramEnvParameterfvARB"));
+		qglGetProgramLocalParameterdvARB = reinterpret_cast<PFNGLGETPROGRAMLOCALPARAMETERDVARBPROC>(ri.GL_GetProcAddress("glGetProgramLocalParameterdvARB"));
+		qglGetProgramLocalParameterfvARB = reinterpret_cast<PFNGLGETPROGRAMLOCALPARAMETERFVARBPROC>(ri.GL_GetProcAddress("glGetProgramLocalParameterfvARB"));
+		qglGetProgramivARB = reinterpret_cast<PFNGLGETPROGRAMIVARBPROC>(ri.GL_GetProcAddress("glGetProgramivARB"));
+		qglGetProgramStringARB = reinterpret_cast<PFNGLGETPROGRAMSTRINGARBPROC>(ri.GL_GetProcAddress("glGetProgramStringARB"));
+		qglIsProgramARB = reinterpret_cast<PFNGLISPROGRAMARBPROC>(ri.GL_GetProcAddress("glIsProgramARB"));
 
 		// Validate the functions we need.
 		if (!qglProgramStringARB || !qglBindProgramARB || !qglDeleteProgramsARB || !qglGenProgramsARB ||
@@ -711,7 +711,7 @@ static void GLimp_InitExtensions()
 	}
 
 #if !defined(__APPLE__)
-	qglStencilOpSeparate = static_cast<PFNGLSTENCILOPSEPARATEPROC>(ri.GL_GetProcAddress("glStencilOpSeparate"));
+	qglStencilOpSeparate = reinterpret_cast<PFNGLSTENCILOPSEPARATEPROC>(ri.GL_GetProcAddress("glStencilOpSeparate"));
 	if (qglStencilOpSeparate)
 	{
 		glConfig.doStencilShadowsInOneDrawcall = qtrue;

--- a/code/rd-vanilla/tr_local.h
+++ b/code/rd-vanilla/tr_local.h
@@ -52,7 +52,7 @@ using dlight_t = struct dlight_s {
 
 // a trRefEntity_t has all the information passed in by
 // the client game, as well as some locally derived info
-using trRefEntity_t = struct {
+using trRefEntity_t = struct trRefEntity_t {
 	refEntity_t	e;
 
 	float		axisLength;		// compensate for non-normalized axis
@@ -68,7 +68,7 @@ using trRefEntity_t = struct {
 
 // trRefdef_t holds everything that comes in refdef_t,
 // as well as the locally generated scene information
-using trRefdef_t = struct {
+using trRefdef_t = struct trRefdef_t {
 	int			x, y, width, height;
 	float		fov_x, fov_y;
 	vec3_t		vieworg;
@@ -104,7 +104,7 @@ using trRefdef_t = struct {
 	int			fogIndex;	//what fog brush the vieworg is in
 };
 
-using orientationr_t = struct {
+using orientationr_t = struct orientationr_t {
 	vec3_t		origin;			// in world coordinates
 	vec3_t		axis[3];		// orientation in world
 	vec3_t		viewOrigin;		// viewParms->or.origin in local coordinates
@@ -212,7 +212,7 @@ using alphaGen_t = enum {
 	AGEN_ONE_MINUS_DOT
 };
 
-using colorGen_t = enum {
+using colorGen_t = enum colorGen_t {
 	CGEN_BAD,
 	CGEN_IDENTITY_LIGHTING,	// tr.identityLight
 	CGEN_IDENTITY,			// always (1,1,1,1)
@@ -258,7 +258,7 @@ using EGLFogOverride = enum {
 	GLFOGOVERRIDE_MAX
 };
 
-using waveForm_t = struct {
+using waveForm_t = struct waveForm_t {
 	genFunc_t	func;
 
 	float base;
@@ -293,7 +293,7 @@ using deformStage_t = struct {
 	float		bulgeSpeed;
 };
 
-using texModInfo_t = struct {
+using texModInfo_t = struct texModInfo_t {
 	texMod_t		type;
 
 	// used for TMOD_TURBULENT and TMOD_STRETCH
@@ -338,7 +338,7 @@ using surfaceSprite_t = struct surfaceSprite_s
 	int				facing;		// Hangdown on vertical sprites, faceup on others.
 };
 
-using textureBundle_t = struct {
+using textureBundle_t = struct textureBundle_t {
 	image_t* image;
 
 	texCoordGen_t	tcGen;
@@ -359,7 +359,7 @@ using textureBundle_t = struct {
 
 #define NUM_TEXTURE_BUNDLES 2
 
-using shaderStage_t = struct {
+using shaderStage_t = struct shaderStage_t {
 	bool			active;
 	bool			isDetail;
 	byte			index;						// index of stage
@@ -516,7 +516,7 @@ using fog_t = struct {
 	float		surface[4];
 };
 
-using viewParms_t = struct {
+using viewParms_t = struct viewParms_t {
 	orientationr_t	ori;
 	orientationr_t	world;
 	vec3_t		pvsOrigin;			// may be different than or.origin for portals
@@ -710,7 +710,7 @@ using mnode_t = struct mnode_s {
 	int			nummarksurfaces;
 };
 
-using bmodel_t = struct {
+using bmodel_t = struct bmodel_t {
 	vec3_t		bounds[2];		// for culling
 	msurface_t* firstSurface;
 	int			numSurfaces;
@@ -723,7 +723,7 @@ using mgrid_t = struct {
 	byte		latLong[2];
 };
 
-using world_t = struct {
+using world_t = struct world_t {
 	char		name[MAX_QPATH];		// ie: maps/tim_dm2.bsp
 	char		baseName[MAX_QPATH];	// ie: tim_dm2
 
@@ -876,7 +876,7 @@ using frontEndCounters_t = struct {
 #define FUNCTABLE_MASK		(FUNCTABLE_SIZE-1)
 
 // the renderer front end should never modify glstate_t
-using glstate_t = struct {
+using glstate_t = struct glstate_t {
 	int			currenttextures[2];
 	int			currenttmu;
 	qboolean	finishCalled;
@@ -901,7 +901,7 @@ using backEndCounters_t = struct {
 
 // all state modified by the back end is seperated
 // from the front end state
-using backEndState_t = struct {
+using backEndState_t = struct backEndState_t {
 	trRefdef_t	refdef;
 	viewParms_t	viewParms;
 	orientationr_t	ori;
@@ -926,7 +926,7 @@ using backEndState_t = struct {
 */
 #define NUM_SCRATCH_IMAGES 16
 
-using trGlobals_t = struct {
+using trGlobals_t = struct trGlobals_t {
 	qboolean				registered;		// cleared at shutdown, set at beginRegistration
 
 	int						visCount;		// incremented every time a new vis cluster is entered
@@ -1744,7 +1744,7 @@ using renderCommand_t = enum {
 
 // all of the information needed by the back end must be
 // contained in a backEndData_t.
-using backEndData_t = struct {
+using backEndData_t = struct backEndData_t {
 	drawSurf_t	drawSurfs[MAX_DRAWSURFS];
 	dlight_t	dlights[MAX_DLIGHTS];
 	trRefEntity_t	entities[MAX_REFENTITIES];

--- a/code/server/server.h
+++ b/code/server/server.h
@@ -63,7 +63,7 @@ using serverState_t = enum
 	SS_GAME // actively running
 };
 
-using server_t = struct
+using server_t = struct server_s
 {
 	serverState_t state;
 	int serverId; // changes each server start
@@ -152,7 +152,7 @@ using challenge_t = struct
 };
 
 // this structure will be cleared only when the game dll changes
-using serverStatic_t = struct
+using serverStatic_t = struct serverStatic_s
 {
 	qboolean initialized; // sv_init has completed
 	client_t* clients; // [sv_maxclients->integer];

--- a/code/server/sv_savegame.cpp
+++ b/code/server/sv_savegame.cpp
@@ -51,7 +51,9 @@ constexpr auto JPEG_IMAGE_QUALITY = 95;
 #include <qcommon/ojk_saved_game_helper_fwd.h>
 #include <cstdint>
 #include <string>
+#if defined(_WIN32)
 #include <corecrt.h>
+#endif
 #include <ctime>
 #include <client/client.h>
 #include <qcommon/cm_public.h>
@@ -162,7 +164,7 @@ void SV_WipeGame_f()
 		return;
 	}
 	SG_WipeSavegame(Cmd_Argv(1));
-	//	Com_Printf("%s has been wiped\n", Cmd_Argv(1));	// wurde gelöscht in german, but we've only got one string
+	//	Com_Printf("%s has been wiped\n", Cmd_Argv(1));	// wurde gelï¿½scht in german, but we've only got one string
 	//	Com_Printf("Ok\n"); // no localization of this
 }
 

--- a/code/ui/ui_local.h
+++ b/code/ui/ui_local.h
@@ -84,7 +84,7 @@ extern void UI_UpdateConnectionMessageString(const char* string);
 constexpr auto UI_FADEOUT = 0;
 constexpr auto UI_FADEIN = 1;
 
-using uiStatic_t = struct
+using uiStatic_t = struct uiStatic_s
 {
 	int frametime;
 	int realtime;
@@ -152,7 +152,7 @@ using playerSpeciesInfo_t = struct
 	playerColor_t* Color;
 };
 
-using uiInfo_t = struct
+using uiInfo_t = struct uiInfo_s
 {
 	displayContextDef_t uiDC;
 

--- a/code/ui/ui_main.cpp
+++ b/code/ui/ui_main.cpp
@@ -47,7 +47,9 @@ extern stringID_table_t animTable[MAX_ANIMATIONS + 1];
 #include "../qcommon/stringed_ingame.h"
 #include "../qcommon/stv_version.h"
 #include "../qcommon/q_shared.h"
+#if defined(_WIN32)
 #include <corecrt.h>
+#endif
 #include <cstdint>
 #include <cctype>
 #include <qcommon/qcommon.h>
@@ -2528,6 +2530,7 @@ static qboolean UI_RunMenuScript(const char** args)
 	if (String_Parse(args, &name))
 	{
 #ifdef NEW_FEEDER_V1
+		int i = 0;
 #ifdef NEW_FEEDER_V6
 		if (Q_stricmp(name, "md_char_init") == 0)
 		{
@@ -2541,7 +2544,7 @@ static qboolean UI_RunMenuScript(const char** args)
 			return qtrue;
 		}
 #endif
-		for (int i = 0; i < TOTAL_ERAS; i++) {
+		for (i = 0; i < TOTAL_ERAS; i++) {
 			if (Q_stricmp(name, era_table[i].name) == 0) {
 				uiEra = i;
 #ifdef NEW_FEEDER_V6
@@ -9636,7 +9639,7 @@ static void Menus_SaveGoToMenu(const char* menuTo)
 UI_CheckVid1Data
 =================
 */
-static void UI_CheckVid1Data(const char* menuTo, const char* warningMenuName)
+void UI_CheckVid1Data(const char* menuTo, const char* warningMenuName)
 {
 	// Determine which menu is currently active (video or in‑game video)
 	const menuDef_t* menu = Menu_GetFocused();

--- a/code/ui/ui_public.h
+++ b/code/ui/ui_public.h
@@ -28,7 +28,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 #define UI_API_VERSION 4
 
-using uiimport_t = struct
+using uiimport_t = struct uiimport_s
 {
 	//============== general Quake services ==================
 
@@ -166,7 +166,7 @@ using dpTypes_t = enum
 	DP_FORCEPOWERS
 };
 
-using uiImport_t = enum
+using uiImport_t = enum uiImport_e
 {
 	UI_ERROR,
 	UI_PRINT,

--- a/code/ui/ui_shared.h
+++ b/code/ui/ui_shared.h
@@ -121,7 +121,7 @@ constexpr auto STRING_POOL_SIZE = (4 * 1024 * 1024);
 
 constexpr auto NUM_CROSSHAIRS = 9;
 
-using cachedAssets_t = struct
+using cachedAssets_t = struct cachedAssets_s
 {
 	qhandle_t qhMediumFont;
 	qhandle_t cursor;
@@ -182,7 +182,7 @@ using cachedAssets_t = struct
 
 struct itemDef_s;
 
-using displayContextDef_t = struct
+using displayContextDef_t = struct displayContextDef_s
 {
 	void (*addRefEntityToScene)(const refEntity_t* re);
 	void (*clearScene)();
@@ -308,7 +308,7 @@ constexpr auto MAX_MENUS = 256;
 #define WINDOW_INTRANSITIONMODEL	0x04000000	// delayed script waiting to run
 #define WINDOW_IGNORE_ESCAPE	0x08000000	// ignore normal closeall menus escape functionality
 
-using rectDef_t = struct
+using rectDef_t = struct rectDef_s
 {
 	float x; // horiz position
 	float y; // vert position
@@ -319,7 +319,7 @@ using rectDef_t = struct
 using UIRectangle = rectDef_t;
 
 // FIXME: do something to separate text vs window stuff
-using windowDef_t = struct
+using windowDef_t = struct windowDef_s
 {
 	UIRectangle rect; // client coord rectangle
 	UIRectangle rectClient; // screen coord rectangle
@@ -348,7 +348,7 @@ using windowDef_t = struct
 
 using Window = windowDef_t;
 
-using colorRangeDef_t = struct
+using colorRangeDef_t = struct colorRangeDef_s
 {
 	vec4_t color; //
 	float low; //
@@ -433,7 +433,7 @@ using itemDef_t = struct itemDef_s
 	qboolean disabledHidden; // hide the item when 'disabled' is true (for generic image items)
 };
 
-using menuDef_t = struct
+using menuDef_t = struct menuDef_s
 {
 	Window window;
 	const char* font; // font
@@ -481,7 +481,7 @@ using textScrollDef_t = struct textScrollDef_s
 	const char* pLines[MAX_TEXTSCROLL_LINES]; // can contain NULL ptrs that you should skip over during paint.
 };
 
-using commandDef_t = struct
+using commandDef_t = struct commandDef_s
 {
 	const char* name;
 	qboolean(*handler)(itemDef_t* item, const char** args);

--- a/lib/gsl-lite/include/gsl/gsl-lite.h
+++ b/lib/gsl-lite/include/gsl/gsl-lite.h
@@ -187,8 +187,8 @@ namespace gsl {
 // GSL.owner: ownership pointers 
 //
 #if gsl_HAVE_SHARED_PTR
-  using std::unique_ptr;
-  using std::shared_ptr;
+  using ::std::unique_ptr;
+  using ::std::shared_ptr;
 #endif
 
 #if gsl_HAVE_ALIAS_TEMPLATE
@@ -215,13 +215,13 @@ namespace gsl {
 
 #if gsl_CONFIG_THROWS_FOR_TESTING
 
-struct fail_fast : public std::runtime_error 
+struct fail_fast : public ::std::runtime_error 
 {
     fail_fast() 
-    : std::runtime_error( "GSL assertion" ) {}
+    : ::std::runtime_error( "GSL assertion" ) {}
     
     explicit fail_fast( char const * const message ) 
-    : std::runtime_error( message ) {}
+    : ::std::runtime_error( message ) {}
 };
 
 inline void fail_fast_assert( bool cond ) 
@@ -241,13 +241,13 @@ inline void fail_fast_assert( bool cond, char const * const message )
 inline void fail_fast_assert( bool cond ) 
 { 
     if ( !cond ) 
-        std::terminate(); 
+        ::std::terminate(); 
 }
 
 inline void fail_fast_assert( bool cond, char const * const ) 
 { 
     if ( !cond ) 
-        std::terminate(); 
+        ::std::terminate(); 
 }
 
 #endif // gsl_CONFIG_THROWS_FOR_TESTING
@@ -263,7 +263,7 @@ class Final_act
 {
 public:
     explicit Final_act( Fn action ) gsl_noexcept
-    : action_( std::move( action ) ) {}
+    : action_( ::std::move( action ) ) {}
     
     ~Final_act() gsl_noexcept { action_(); }
 
@@ -280,7 +280,7 @@ Final_act<Fn> finally( Fn const & action ) gsl_noexcept
 template< class Fn >
 Final_act<Fn> finally( Fn && action ) gsl_noexcept
 { 
-    return Final_act<Fn>( std::forward<Fn>( action ) ); 
+    return Final_act<Fn>( ::std::forward<Fn>( action ) ); 
 }
 
 #else // gsl_CPP11_OR_GREATER
@@ -316,7 +316,7 @@ T narrow_cast( U u ) gsl_noexcept
     return static_cast<T>( u ); 
 }
 
-struct narrowing_error : public std::exception {};
+struct narrowing_error : public ::std::exception {};
 
 template< class T, class U >
 T narrow( U u ) 
@@ -335,7 +335,7 @@ T narrow( U u )
 //
 
 //
-// at() - Bounds-checked way of accessing static arrays, std::array, std::vector.
+// at() - Bounds-checked way of accessing static arrays, ::std::array, ::std::vector.
 //
 
 template< class T, size_t N >
@@ -348,7 +348,7 @@ T & at( T(&arr)[N], size_t index )
 #if gsl_HAVE_ARRAY
 
 template< class T, size_t N >
-T & at( std::array<T, N> & arr, size_t index ) 
+T & at( ::std::array<T, N> & arr, size_t index ) 
 { 
     Expects( index < N ); 
     return arr[index]; 
@@ -378,11 +378,11 @@ public:
 #if gsl_HAVE_DEFAULT_FUNCTION_TEMPLATE_ARG
 
     template< typename U, typename Dummy = 
-        typename std::enable_if<std::is_convertible<U, T>::value, void>::type > 
+        typename ::std::enable_if<::std::is_convertible<U, T>::value, void>::type > 
     not_null( not_null<U> const & other ) : ptr_( other.get() ) {}
 
     template< typename U, typename Dummy = 
-        typename std::enable_if<std::is_convertible<U, T>::value, void>::type > 
+        typename ::std::enable_if<::std::is_convertible<U, T>::value, void>::type > 
     not_null & operator=( not_null<U> const & other ) 
     { 
         ptr_ = other.get(); 
@@ -405,8 +405,8 @@ public:
 private:
     // Prevent compilation when initialized with a nullptr or literal 0:
 #if gsl_HAVE_NULLPTR
-    not_null(             std::nullptr_t );
-    not_null & operator=( std::nullptr_t );
+    not_null(             ::std::nullptr_t );
+    not_null & operator=( ::std::nullptr_t );
 #endif
     not_null(             int );
     not_null & operator=( int );
@@ -448,7 +448,7 @@ private:
   enum class byte : std::uint8_t {};
 #elif gsl_HAVE_SIZED_TYPES
 # include <cstdint>
-  typedef std::uint8_t byte;
+  typedef ::std::uint8_t byte;
 #else
   typedef unsigned char byte;
 #endif
@@ -473,14 +473,14 @@ public:
     typedef const_pointer const_iterator;
     
 #if gsl_BETWEEN( gsl_COMPILER_MSVC_VERSION, 6, 7 )
-    typedef std::reverse_iterator< iterator, T >             reverse_iterator;
-    typedef std::reverse_iterator< const_iterator, const T > const_reverse_iterator;
+    typedef ::std::reverse_iterator< iterator, T >             reverse_iterator;
+    typedef ::std::reverse_iterator< const_iterator, const T > const_reverse_iterator;
 #else
-    typedef std::reverse_iterator< iterator >                reverse_iterator;
-    typedef std::reverse_iterator< const_iterator >          const_reverse_iterator;
+    typedef ::std::reverse_iterator< iterator >                reverse_iterator;
+    typedef ::std::reverse_iterator< const_iterator >          const_reverse_iterator;
 #endif
 
-    typedef typename std::iterator_traits< iterator >::difference_type difference_type;    
+    typedef typename ::std::iterator_traits< iterator >::difference_type difference_type;    
 
     gsl_constexpr14 array_view()
         : begin_( NULL )
@@ -490,7 +490,7 @@ public:
     }
 
 #if gsl_HAVE_NULLPTR
-    gsl_constexpr14 array_view( std::nullptr_t, size_type size )
+    gsl_constexpr14 array_view( ::std::nullptr_t, size_type size )
         : begin_( nullptr )
         , end_  ( nullptr )
     {
@@ -528,7 +528,7 @@ public:
 
 #if gsl_HAVE_ARRAY
     template< class U, size_t N >
-    gsl_constexpr14 array_view( std::array< U, N > & arr ) 
+    gsl_constexpr14 array_view( ::std::array< U, N > & arr ) 
         : begin_( arr.data() )
         , end_  ( arr.data() + N )
     {}
@@ -624,7 +624,7 @@ public:
     gsl_constexpr14 bool operator==( array_view const & other ) const gsl_noexcept
     {
         return  size() == other.size() 
-            && (begin_ == other.begin_ || std::equal( this->begin(), this->end(), other.begin() ) );	    
+            && (begin_ == other.begin_ || ::std::equal( this->begin(), this->end(), other.begin() ) );	    
     }
 
     gsl_constexpr14 bool operator!=( array_view const & other ) const gsl_noexcept 
@@ -634,7 +634,7 @@ public:
 
     gsl_constexpr14 bool operator< ( array_view const & other ) const gsl_noexcept
     { 
-        return std::lexicographical_compare( this->begin(), this->end(), other.begin(), other.end() ); 
+        return ::std::lexicographical_compare( this->begin(), this->end(), other.begin(), other.end() ); 
     }
 
     gsl_constexpr14 bool operator<=( array_view const & other ) const gsl_noexcept
@@ -670,7 +670,7 @@ public:
 
     gsl_constexpr14 size_type size() const gsl_noexcept
     {
-        return std::distance( begin_, end_ );
+        return ::std::distance( begin_, end_ );
     }
 
     gsl_constexpr14 size_type length() const gsl_noexcept
@@ -695,7 +695,7 @@ public:
 
     void swap( array_view & other ) gsl_noexcept
     {
-        using std::swap;
+        using ::std::swap;
         swap( begin_, other.begin_ );
         swap( end_  , other.end_   );
     }
@@ -762,7 +762,7 @@ gsl_constexpr14 array_view<T> as_array_view( T (&arr)[N] )
 
 #if gsl_HAVE_ARRAY
 template< typename T, size_t N >
-gsl_constexpr14 array_view<T> as_array_view( std::array<T,N> & arr )
+gsl_constexpr14 array_view<T> as_array_view( ::std::array<T,N> & arr )
 {
     return array_view<T>( arr );
 }
@@ -776,7 +776,7 @@ gsl_constexpr14 auto as_array_view( Cont & cont ) ->  array_view< typename Cont:
 }
 #else
 template< class T >
-array_view<T> as_array_view( std::vector<T> & cont )
+array_view<T> as_array_view( ::std::vector<T> & cont )
 { 
     return array_view<T>( cont );
 }
@@ -798,24 +798,24 @@ typedef array_view< const wchar_t > cwstring_view;
 
 // to_string() allow (explicit) conversions from string_view to string
 
-inline std::string to_string( string_view const & view )
+inline ::std::string to_string( string_view const & view )
 {
-    return std::string( view.data(), view.length() );
+    return ::std::string( view.data(), view.length() );
 }
 
-inline std::string to_string( cstring_view const & view )
+inline ::std::string to_string( cstring_view const & view )
 {
-    return std::string( view.data(), view.length() );
+    return ::std::string( view.data(), view.length() );
 }
 
-inline std::wstring to_string( wstring_view const & view )
+inline ::std::wstring to_string( wstring_view const & view )
 {
-    return std::wstring( view.data(), view.length() );
+    return ::std::wstring( view.data(), view.length() );
 }
 
-inline std::wstring to_string( cwstring_view const & view )
+inline ::std::wstring to_string( cwstring_view const & view )
 {
-    return std::wstring( view.data(), view.length() );
+    return ::std::wstring( view.data(), view.length() );
 }
 
 //
@@ -829,14 +829,14 @@ inline std::wstring to_string( cwstring_view const & view )
 namespace detail {
 
 template<class T, class SizeType, const T Sentinel>
-static array_view<T> ensure_sentinel( T * seq, SizeType max = std::numeric_limits<SizeType>::max() )
+static array_view<T> ensure_sentinel( T * seq, SizeType max = ::std::numeric_limits<SizeType>::max() )
 {
     typedef T * pointer;
-    typedef typename std::iterator_traits<pointer>::difference_type difference_type;
+    typedef typename ::std::iterator_traits<pointer>::difference_type difference_type;
     
     pointer cur = seq;
 
-    while ( std::distance( seq, cur ) < static_cast<difference_type>( max ) && *cur != Sentinel ) 
+    while ( ::std::distance( seq, cur ) < static_cast<difference_type>( max ) && *cur != Sentinel ) 
         ++cur;
     
     Expects( *cur == Sentinel );
@@ -852,7 +852,7 @@ static array_view<T> ensure_sentinel( T * seq, SizeType max = std::numeric_limit
 //
 
 template< class T >
-inline array_view<T> ensure_z( T * const & sz, size_t max = std::numeric_limits<size_t>::max() )
+inline array_view<T> ensure_z( T * const & sz, size_t max = ::std::numeric_limits<size_t>::max() )
 {
     return detail::ensure_sentinel<T, size_t, 0>( sz, max );
 //    return detail::ensure<T, size_t, 0>::sentinel( sz, max );
@@ -867,7 +867,7 @@ array_view<T> ensure_z( T (&sz)[N] )
 # if gsl_HAVE_TYPE_TRAITS
 
 template< class Cont >
-array_view< typename std::remove_pointer<typename Cont::pointer>::type > 
+array_view< typename ::std::remove_pointer<typename Cont::pointer>::type > 
 ensure_z( Cont& cont )
 {
     return ensure_z( cont.data(), cont.length() );

--- a/shared/qcommon/q_string.c
+++ b/shared/qcommon/q_string.c
@@ -10,7 +10,9 @@
 #include <string.h>
 
 #include "q_color.h"
+#if defined(_WIN32)
 #include <corecrt.h>
+#endif
 #include <stdarg.h>
 
 int Q_isprint(const int c)
@@ -54,7 +56,7 @@ int Q_isupper(const int c)
 
 int Q_isalpha(const int c)
 {
-	if (c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z')
+	if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'))
 		return 1;
 	return 0;
 }

--- a/shared/sdl/sdl_window.cpp
+++ b/shared/sdl/sdl_window.cpp
@@ -26,7 +26,9 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "sys/sys_local.h"
 #include "sdl_icon.h"
 #include <string.h>
+#if defined(_WIN32)
 #include <VersionHelpers.h>
+#endif
 #include <SDL_video.h>
 #include <sys/sys_public.h>
 #include <SDL_error.h>

--- a/shared/sys/sys_local.h
+++ b/shared/sys/sys_local.h
@@ -31,6 +31,7 @@ void IN_Restart(void);
 void Sys_PlatformInit();
 void Sys_PlatformExit();
 char* Sys_ConsoleInput();
+void Sys_AnsiColorPrint(const char *msg);
 void Sys_QueEvent(int ev_time, sysEventType_t ev_type, int value, int value2, int ptrLength, void* ptr);
 void Sys_SigHandler(int signal);
 

--- a/shared/sys/sys_main.cpp
+++ b/shared/sys/sys_main.cpp
@@ -533,8 +533,8 @@ void* Sys_LoadLegacyGameDll(const char* name, VMMainProc** vmMain, SystemCallPro
 
 	using DllEntryProc = void QDECL(SystemCallProc* syscallptr);
 
-	auto* dllEntry = static_cast<DllEntryProc*>(Sys_LoadFunction(libHandle, "dllEntry"));
-	*vmMain = static_cast<VMMainProc*>(Sys_LoadFunction(libHandle, "vmMain"));
+	auto* dllEntry = reinterpret_cast<DllEntryProc*>(Sys_LoadFunction(libHandle, "dllEntry"));
+	*vmMain = reinterpret_cast<VMMainProc*>(Sys_LoadFunction(libHandle, "vmMain"));
 
 	if (!*vmMain || !dllEntry)
 	{
@@ -591,7 +591,7 @@ void* Sys_LoadSPGameDll(const char* name, GetGameAPIProc** GetGameAPI)
 			return nullptr;
 	}
 
-	*GetGameAPI = static_cast<GetGameAPIProc*>(Sys_LoadFunction(libHandle, "GetGameAPI"));
+	*GetGameAPI = reinterpret_cast<GetGameAPIProc*>(Sys_LoadFunction(libHandle, "GetGameAPI"));
 	if (!*GetGameAPI)
 	{
 		Com_DPrintf("%s(%s) failed to find GetGameAPI function:\n...%s!\n", __FUNCTION__, name, Sys_LibraryError());
@@ -667,7 +667,7 @@ void* Sys_LoadGameDll(const char* name, GetModuleAPIProc** moduleAPI)
 		}
 	}
 
-	*moduleAPI = static_cast<GetModuleAPIProc*>(Sys_LoadFunction(libHandle, "GetModuleAPI"));
+	*moduleAPI = reinterpret_cast<GetModuleAPIProc*>(Sys_LoadFunction(libHandle, "GetModuleAPI"));
 	if (!*moduleAPI)
 	{
 		Com_DPrintf("Sys_LoadGameDll(%s) failed to find GetModuleAPI function:\n...%s!\n", name, Sys_LibraryError());

--- a/shared/sys/sys_public.h
+++ b/shared/sys/sys_public.h
@@ -65,7 +65,7 @@ NON-PORTABLE SYSTEM SERVICES
 //	MAX_JOYSTICK_AXIS
 //};
 
-using sysEventType_t = enum
+using sysEventType_t = enum sysEventType_e
 {
 	// bk001129 - make sure SE_NONE is zero
 	SE_NONE = 0,

--- a/shared/sys/sys_unix.cpp
+++ b/shared/sys/sys_unix.cpp
@@ -174,9 +174,9 @@ const char *Sys_Basename( char *path )
 Sys_Dirname
 ==================
 */
-const char *Sys_Dirname( char *path )
+const char *Sys_Dirname( const char *path )
 {
-	return dirname( path );
+	return dirname( const_cast<char*>(path) );
 }
 
 /*


### PR DESCRIPTION
…st/reinterpret_cast for function pointers, added Windows guards for platform-specific code

- Named anonymous types (enum/struct) to fix linkage errors in GCC
- Changed static_cast to reinterpret_cast for void* to function pointer casts (invalid in GCC)
- Added #ifdef _WIN32 guards for __cdecl, libpng includes, and random/crandom overrides
- Fixed goto crossing initialization errors in g_utils.cpp and tr_image_png.cpp
- Removed duplicate g_update7firststartup/g_totgfirststartup definitions from cg_main.cpp
- Fixed stricmp->Q_stricmp and sizeof type syntax issues