### PR TITLE
Fix Linux compilation errors and warnings

### DIFF
--- a/code/mp3code/towave.c
+++ b/code/mp3code/towave.c
@@ -185,7 +185,7 @@ char PCM_Buffer[PCM_BUFBYTES]; // better off being declared, so we don't do mall
 
 typedef struct
 {
-	int (*decode_init)(MPEG_HEAD* h, int framebytes_arg,
+	int (*decode_init)(const MPEG_HEAD* h, int framebytes_arg,
 		int reduction_code, int transform_code,
 		int convert_code, int freq_limit);
 	void (*decode_info)(DEC_INFO* info);

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -144,7 +144,7 @@ constexpr auto OPENJKGAME = "MovieDuels-SP";
 #endif
 
 #include "qcommon/q_platform.h"
-#include "ojk_saved_game_helper_fwd.h"
+#include "ojk_saved_game_helper.h"
 
 // ================================================================
 // TYPE DEFINITIONS


### PR DESCRIPTION
- Include full ojk_saved_game_helper.h instead of forward declaration in q_shared.h to fix undefined template errors with enum types
- Add const to MPEG_HEAD* in AUDIO struct to fix incompatible pointer type warning in towave.c