### PR TITLE
Fixed blaster bolt damage stacking due to early return in G_MissileIm…

### DIFF
--- a/code/game/g_missile.cpp
+++ b/code/game/g_missile.cpp
@@ -2211,10 +2211,10 @@ void G_MissileImpacted(gentity_t* ent, gentity_t* other, vec3_t impact_pos, vec3
 				if (other->client->painCooldownTime > level.time)
 				{
 					// Still cooling down → skip pain anim
-					return;
 				}
-
-				int pain_anim = -1;
+				else
+				{
+					int pain_anim = -1;
 
 				if (Q_irand(0, 3)) // 75% chance
 				{
@@ -2243,6 +2243,7 @@ void G_MissileImpacted(gentity_t* ent, gentity_t* other, vec3_t impact_pos, vec3
 						other->client->ps.torsoAnimTimer = 400;
 					}
 					other->client->painCooldownTime = level.time + 2000;// 2 second cooldown on pain anims
+				}
 				}
 			}
 


### PR DESCRIPTION
…pacted

Root cause: In G_MissileImpacted(), when a bolt hit a target whose painCooldownTime was still active (2-second window from a previous hit), the early return at line 2214 exited the function AFTER G_Damage() was called but BEFORE the missile entity was cleaned up (freeAfterEvent, eType = ET_GENERAL). The missile survived and G_RunMissile() re-processed it every frame, calling G_Damage() again each time - stacking damage every frame for up to 2 seconds per bolt.

Fix: Replaced the early return with an if/else structure so the painCooldownTime check only skips the pain animation. The missile cleanup code below now always executes, ensuring each bolt deals damage exactly once.