### PR TITLE
Fix SP compile error from 07b8d7c: add missing saberAttackSequence to…

### DIFF
--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -2036,6 +2036,7 @@ public:
 	int saberEventFlags;
 	int saberAnimLevel;
 	int saberAttackChainCount;
+	int saberAttackSequence;
 	int saberFatigueChainCount;
 	int BlasterAttackChainCount;
 	int saberLockTime;


### PR DESCRIPTION
… PlayerStateBase

The cherry-pick of commit 07b8d7c added saber swing hit tracking that references ps.saberAttackSequence, but the SP PlayerStateBase class in q_shared.h was missing this member (it only existed in the MP playerState_s struct). Adding it to PlayerStateBase fixes the 'not a member of PlayerStateBase<saberInfo_t>' compile error.